### PR TITLE
feat: add MiniMax provider support with quick-fill presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,15 @@ TZ=Asia/Shanghai
 访问 `/geo_admin/`，使用管理员账号进入后台。默认管理员用户名和密码：`admin / admin888`，登录后可自行修改。
 
 2. 配置 AI 模型  
-在“AI 配置中心 → AI 模型管理”里添加模型，填写 API 地址、模型 ID 和密钥。
+在”AI 配置中心 → AI 模型管理”里添加模型，填写 API 地址、模型 ID 和密钥。可使用**服务商快速填充**按钮一键预填常用服务商配置：
+
+   | 服务商 | API 地址 | 模型 ID |
+   |--------|---------|--------|
+   | **MiniMax** | `https://api.minimax.io` | `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` |
+   | OpenAI | `https://api.openai.com` | `gpt-4o` |
+   | DeepSeek | `https://api.deepseek.com` | `deepseek-chat` |
+
+   只要服务商提供 OpenAI 兼容的 `/v1/chat/completions` 接口，均可按同样方式接入。
 
 3. 准备素材  
 创建标题库、图片库、知识库和提示词模板。

--- a/README_en.md
+++ b/README_en.md
@@ -173,7 +173,15 @@ TZ=Asia/Shanghai
 Visit `/geo_admin/` and sign in with the admin account. Default credentials: `admin / admin888`. You can change these after logging in.
 
 2. Configure AI Models  
-Go to "AI Configuration Center → AI Model Management" to add models — fill in the API URL, model ID, and API key.
+Go to "AI Configuration Center → AI Model Management" to add models — fill in the API URL, model ID, and API key. Use the **Quick Provider Fill** buttons to pre-fill settings for popular providers:
+
+   | Provider | API Base URL | Model ID |
+   |----------|-------------|---------|
+   | **MiniMax** | `https://api.minimax.io` | `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` |
+   | OpenAI | `https://api.openai.com` | `gpt-4o` |
+   | DeepSeek | `https://api.deepseek.com` | `deepseek-chat` |
+
+   Any provider that exposes an OpenAI-compatible `/v1/chat/completions` endpoint can be added the same way.
 
 3. Prepare Materials  
 Create title libraries, image libraries, knowledge bases, and prompt templates.

--- a/admin/ai-models.php
+++ b/admin/ai-models.php
@@ -477,6 +477,30 @@ require_once __DIR__ . '/includes/header.php';
                         <input type="hidden" name="action" id="formAction" value="create_model">
                         <input type="hidden" name="id" id="modelId" value="">
 
+                        <!-- 服务商快速填充 -->
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-2">服务商快速填充</label>
+                            <div class="flex flex-wrap gap-2">
+                                <button type="button" onclick="fillPreset('minimax')"
+                                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                    MiniMax
+                                </button>
+                                <button type="button" onclick="fillPreset('minimax_highspeed')"
+                                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                    MiniMax Highspeed
+                                </button>
+                                <button type="button" onclick="fillPreset('openai')"
+                                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                    OpenAI
+                                </button>
+                                <button type="button" onclick="fillPreset('deepseek')"
+                                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                    DeepSeek
+                                </button>
+                            </div>
+                            <p class="mt-1 text-xs text-gray-500">点击自动填充服务商配置，填写 API 密钥后即可保存</p>
+                        </div>
+
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                             <div>
                                 <label for="name" class="block text-sm font-medium text-gray-700">模型名称 *</label>
@@ -598,6 +622,48 @@ require_once __DIR__ . '/includes/header.php';
         // 关闭模态框
         function closeModelModal() {
             document.getElementById('modelModal').classList.add('hidden');
+        }
+
+        // 服务商预设配置
+        const PROVIDER_PRESETS = {
+            'minimax': {
+                name: 'MiniMax M2.7',
+                version: 'M2.7',
+                model_id: 'MiniMax-M2.7',
+                api_url: 'https://api.minimax.io',
+                model_type: 'chat',
+            },
+            'minimax_highspeed': {
+                name: 'MiniMax M2.7 Highspeed',
+                version: 'M2.7',
+                model_id: 'MiniMax-M2.7-highspeed',
+                api_url: 'https://api.minimax.io',
+                model_type: 'chat',
+            },
+            'openai': {
+                name: 'GPT-4o',
+                version: '',
+                model_id: 'gpt-4o',
+                api_url: 'https://api.openai.com',
+                model_type: 'chat',
+            },
+            'deepseek': {
+                name: 'DeepSeek Chat',
+                version: '',
+                model_id: 'deepseek-chat',
+                api_url: 'https://api.deepseek.com',
+                model_type: 'chat',
+            },
+        };
+
+        function fillPreset(provider) {
+            const preset = PROVIDER_PRESETS[provider];
+            if (!preset) return;
+            document.getElementById('name').value = preset.name;
+            document.getElementById('version').value = preset.version;
+            document.getElementById('model_id').value = preset.model_id;
+            document.getElementById('api_url').value = preset.api_url;
+            document.getElementById('model_type').value = preset.model_type;
         }
 
         // 删除模型

--- a/docs/AI_PROJECT_GUIDE.md
+++ b/docs/AI_PROJECT_GUIDE.md
@@ -352,8 +352,12 @@ define('SECRET_KEY', 'your-secret-key-change-this-in-production');
 
 ### 2. AI API配置
 ```
-提供商: 兔子API (Tu-zi API)
-默认端点: https://apicdn.tu-zi.com/v1/chat/completions
+支持服务商（任何提供 OpenAI 兼容 /v1/chat/completions 接口的平台均可接入）：
+- MiniMax:  https://api.minimax.io   （模型：MiniMax-M2.7、MiniMax-M2.7-highspeed）
+- OpenAI:   https://api.openai.com   （模型：gpt-4o 等）
+- DeepSeek: https://api.deepseek.com （模型：deepseek-chat 等）
+- 兔子API:   https://api.tu-zi.com    （聚合代理，支持多种模型）
+
 认证方式: Bearer Token
 请求格式: OpenAI兼容
 ```

--- a/docs/AI_PROJECT_GUIDE_en.md
+++ b/docs/AI_PROJECT_GUIDE_en.md
@@ -380,8 +380,12 @@ define('SECRET_KEY', 'your-secret-key-change-this-in-production');
 
 ### 2. AI API Configuration
 ```
-Provider: Tu-zi API (Tuzi API)
-Default Endpoint: https://apicdn.tu-zi.com/v1/chat/completions
+Supported Providers (any OpenAI-compatible /v1/chat/completions endpoint):
+- MiniMax:  https://api.minimax.io   (models: MiniMax-M2.7, MiniMax-M2.7-highspeed)
+- OpenAI:   https://api.openai.com   (models: gpt-4o, etc.)
+- DeepSeek: https://api.deepseek.com (models: deepseek-chat, etc.)
+- Tu-zi:    https://api.tu-zi.com    (aggregator, supports many models)
+
 Authentication: Bearer Token
 Request Format: OpenAI-compatible
 ```

--- a/includes/database.php
+++ b/includes/database.php
@@ -442,11 +442,11 @@ class Database {
         // 插入示例AI模型配置（开源安全占位，不包含真实密钥）
         $stmt = $this->pdo->prepare("INSERT INTO ai_models (name, version, api_key, model_id, api_url, daily_limit, status) VALUES (?, ?, ?, ?, ?, ?, ?)");
         $stmt->execute([
-            'Sample AI Model',
-            'example',
+            'MiniMax M2.7 (示例)',
+            'M2.7',
             '',
-            'replace-with-your-model-id',
-            'https://api.openai.com/v1/chat/completions',
+            'MiniMax-M2.7',
+            'https://api.minimax.io',
             0,
             'inactive'
         ]);


### PR DESCRIPTION
## Summary

This PR adds explicit MiniMax provider support to GEOFlow and improves the AI model configuration experience for all users.

### Changes

- **Admin UI quick-fill presets** (`admin/ai-models.php`): Added a "Provider Quick Fill" section in the AI model creation/edit modal with one-click preset buttons for popular providers (MiniMax M2.7, MiniMax M2.7 Highspeed, OpenAI, DeepSeek). Clicking a preset auto-fills the model name, model ID, and API base URL — users only need to enter their API key.

- **Bug fix** (`includes/database.php`): Fixed incorrect seed data where `api_url` was set to the full endpoint `https://api.openai.com/v1/chat/completions`. The code in `ai_engine.php` already appends `/v1/chat/completions`, so the stored value must be only the base URL. Updated to use `https://api.minimax.io` as a valid working example.

- **Documentation** (`README.md`, `README_en.md`, `docs/AI_PROJECT_GUIDE.md`, `docs/AI_PROJECT_GUIDE_en.md`): Added a provider table listing MiniMax, OpenAI, and DeepSeek with their base URLs and model IDs. Clarified that any OpenAI-compatible `/v1/chat/completions` endpoint can be used.

### MiniMax API Reference

GEOFlow uses the OpenAI-compatible chat completions format. MiniMax exposes a compatible endpoint:

- **Base URL**: `https://api.minimax.io`
- **Endpoint**: `/v1/chat/completions` (appended automatically by the system)
- **Models**: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed` (faster)
- **Auth**: Bearer token via `MINIMAX_API_KEY`
- **Docs**: https://platform.minimax.io/docs/api-reference/text-openai-api

Integration tested: MiniMax API returns valid `choices[0].message.content` in OpenAI-compatible format with `temperature: 0.7` and `max_tokens: 4000` — exactly the parameters GEOFlow sends.