### PR TITLE
修复 Docker 首次启动与二级目录图片地址

### DIFF
--- a/app/Support/GeoFlow/ImageUrlNormalizer.php
+++ b/app/Support/GeoFlow/ImageUrlNormalizer.php
@@ -7,6 +7,9 @@ namespace App\Support\GeoFlow;
  */
 final class ImageUrlNormalizer
 {
+    /**
+     * 将图片路径归一化为可公开访问的 URL。
+     */
     public static function toPublicUrl(string $path): string
     {
         $normalized = str_replace('\\', '/', trim($path));
@@ -34,16 +37,19 @@ final class ImageUrlNormalizer
         }
 
         if (str_starts_with($withoutLeadingSlash, 'storage/')) {
-            return '/'.$withoutLeadingSlash;
+            return asset($withoutLeadingSlash);
         }
 
         if (str_starts_with($withoutLeadingSlash, 'uploads/')) {
-            return '/storage/'.$withoutLeadingSlash;
+            return asset('storage/'.$withoutLeadingSlash);
         }
 
-        return '/'.ltrim($withoutLeadingSlash, '/');
+        return asset(ltrim($withoutLeadingSlash, '/'));
     }
 
+    /**
+     * 清理图片 alt 文案，避免把文件名直接展示给读者。
+     */
     public static function readableAlt(string $alt): string
     {
         $alt = trim($alt);

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -20,7 +20,7 @@ RUN composer dump-autoload \
     --no-interaction \
     --classmap-authoritative \
     --no-scripts \
- && php artisan package:discover --ansi
+ && BROADCAST_CONNECTION=null php artisan package:discover --ansi
 
 FROM php:8.4-fpm-bookworm
 

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -8,6 +8,12 @@ if [ ! -f .env ]; then
   exit 1
 fi
 
+# Compose 会把 .env.prod 中的 APP_KEY= 注入为「空环境变量」；
+# 若不清掉，它会覆盖后续写入的 .env 文件，导致首次启动后的应用容器仍然 500。
+if [ -z "${APP_KEY:-}" ] || ! printf '%s' "${APP_KEY}" | grep -q '^base64:'; then
+  unset APP_KEY
+fi
+
 # .env.prod 为可写挂载时，无密钥则自动生成（宿主机可无 PHP）。
 if ! grep -q '^APP_KEY=base64:' .env 2>/dev/null; then
   echo "[entrypoint-prod] php artisan key:generate --force"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,12 @@ if [ ! -f .env ] && [ -f .env.example ]; then
   cp .env.example .env
 fi
 
+# Compose 会把 .env 中的 APP_KEY= 注入为「空环境变量」；
+# 若不清掉，它会覆盖 init 写回的 .env 文件，导致后续服务仍读到空密钥。
+if [ -z "${APP_KEY:-}" ] || ! printf '%s' "${APP_KEY}" | grep -q '^base64:'; then
+  unset APP_KEY
+fi
+
 COMPOSER_NEED_POST_INSTALL=false
 COMPOSER_ON_START="${COMPOSER_ON_START:-true}"
 RUN_COMPOSER=false
@@ -37,9 +43,6 @@ fi
 
 # 自动初始化 APP_KEY（仅在 .env 里缺失时生成，避免每次重置密钥）
 if [ "${AUTO_GENERATE_APP_KEY:-false}" = "true" ]; then
-  if [ -z "${APP_KEY:-}" ] || ! printf '%s' "${APP_KEY}" | grep -q '^base64:'; then
-    unset APP_KEY
-  fi
   if ! grep -Eq '^APP_KEY=base64:' .env 2>/dev/null; then
     php artisan key:generate --force --no-interaction
   fi


### PR DESCRIPTION
## 概要
- 修复 Docker 首次启动时空 `APP_KEY` 环境变量覆盖 `.env` 中密钥的问题，避免首次访问 500。
- 在生产构建的 `package:discover` 阶段临时关闭广播连接，避免 Reverb 密钥未配置时构建失败。
- 将本地图片路径交给 Laravel 的资源 URL 生成器处理，使部署在 `/wiki` 等二级目录时图片地址能跟随 `APP_URL` / `ASSET_URL`。

## 测试
- 已执行 `php -l app/Support/GeoFlow/ImageUrlNormalizer.php`
- 已执行 `php -l app/Providers/AppServiceProvider.php`
- 本次未重新跑完整测试套件