### PR TITLE
Use relative admin fetch URLs

### DIFF
--- a/resources/views/admin/ai-models/index.blade.php
+++ b/resources/views/admin/ai-models/index.blade.php
@@ -328,9 +328,9 @@
             testFailedPrefix: @json(__('admin.ai_models.test_failed_prefix')),
             testNetworkError: @json(__('admin.ai_models.test_network_error')),
         };
-        const UPDATE_URL_TEMPLATE = @json(route('admin.ai-models.update', ['modelId' => '__MODEL_ID__']));
-        const DELETE_URL_TEMPLATE = @json(route('admin.ai-models.delete', ['modelId' => '__MODEL_ID__']));
-        const TEST_URL_TEMPLATE = @json(route('admin.ai-models.test', ['modelId' => '__MODEL_ID__']));
+        const UPDATE_URL_TEMPLATE = @json(route('admin.ai-models.update', ['modelId' => '__MODEL_ID__'], false));
+        const DELETE_URL_TEMPLATE = @json(route('admin.ai-models.delete', ['modelId' => '__MODEL_ID__'], false));
+        const TEST_URL_TEMPLATE = @json(route('admin.ai-models.test', ['modelId' => '__MODEL_ID__'], false));
 
         const PROVIDER_PRESETS = {
             minimax: {name: 'MiniMax M2.7', version: 'M2.7', model_id: 'MiniMax-M2.7', api_url: 'https://api.minimax.io', model_type: 'chat'},

--- a/resources/views/admin/tasks/index.blade.php
+++ b/resources/views/admin/tasks/index.blade.php
@@ -401,8 +401,8 @@
 <script>
 const TASK_I18N = @json($taskI18n, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
 const TASK_REALTIME = @json($taskRealtime, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
-const TASK_HEALTH_URL = @js(route('admin.tasks.health'));
-const TASK_BATCH_URL = @js(route('admin.tasks.batch'));
+const TASK_HEALTH_URL = @js(route('admin.tasks.health', [], false));
+const TASK_BATCH_URL = @js(route('admin.tasks.batch', [], false));
 const TASK_INITIAL_OVERVIEW = @json($taskInitialOverview, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
 const TASK_TEXT = {
     workerNone: @js(__('admin.tasks.worker.none')),


### PR DESCRIPTION
## 背景

在一次 GEOFlow 生产环境部署中遇到了后台管理页的前端请求失败问题。

部署环境中，服务运行在 Docker / Nginx / Laravel 组合下，并通过 HTTPS 域名访问后台。当 `APP_URL`、反向代理入口、内网访问地址或实际浏览器访问 origin 不完全一致时，后台页面中由 `route(...)` 生成的绝对 URL 会导致浏览器 `fetch()` 触发跨源请求，从而在请求到达 Laravel 之前直接失败。

实际表现包括：

- 在「AI 模型」页面点击测试模型时，前端提示网络请求异常。
- 在「任务管理」页面点击停止当前任务时，前端提示 `Failed to fetch`。

后端接口本身可以正常工作，问题主要出现在前端 JavaScript 使用绝对 URL 发起请求时。

## 当前现状

相关后台页面中，部分 JavaScript 请求地址使用 Laravel `route(...)` 默认生成绝对 URL：

- AI 模型页面：
  - 更新模型
  - 删除模型
  - 测试模型连接
- 任务管理页面：
  - 任务健康状态刷新
  - 批量启动 / 停止任务

这些接口都属于后台管理功能，并且仍然由现有的后台认证、权限中间件和 CSRF 机制保护。

## 修改方式

本次修改只调整后台页面中 JavaScript 使用的接口 URL 生成方式：

- 将相关 `route(...)` 调用改为相对 URL 输出。
- 不修改后端 Controller。
- 不修改路由定义。
- 不修改认证、权限、Session 或 CSRF 逻辑。
- 不修改请求 method、payload 或业务行为。

修改后，后台 JavaScript 请求会发往当前页面同源下的 `/geo_admin/...` 路径，从而避免因为 `APP_URL` 与实际访问 origin 不一致导致浏览器跨源失败。

涉及文件：

- `resources/views/admin/ai-models/index.blade.php`
- `resources/views/admin/tasks/index.blade.php`

## 安全性说明

这次修改不降低后台接口安全性。

原因如下：

- 后台路由仍位于受保护的 admin 路由组内。
- 相关 POST 请求仍然携带 CSRF token。
- 认证、权限、中间件、Controller 均未改变。
- 相对 URL 只影响浏览器请求的目标地址生成方式，不会绕过登录或权限校验。
- 请求仍然只能在当前页面所在 origin 下访问对应后台接口。

因此，本次修改的目标是提升反向代理、多域名或内网/公网混合访问场景下的部署兼容性，而不是改变安全模型。

## 测试

已完成以下验证：

- 本地执行 `git diff --check`，未发现格式或空白问题。
- 确认 diff 仅涉及两个后台 Blade 视图文件。
- 确认修改内容仅为 Laravel `route(...)` 生成相对 URL。
- 确认相关请求仍保留原有 CSRF token。
- 在生产 Docker 部署中验证过同类修复：
  - AI 模型测试接口可正常请求。
  - 任务管理停止任务请求不再因跨源 URL 生成问题触发 `Failed to fetch`。
  - 首页和后台页面访问正常。
  - 相关容器健康状态正常。

## 兼容性影响

该修改保持原有路由路径不变，只改变前端 JavaScript 中 URL 的生成形式。

对于正常以 `APP_URL` 对应域名访问后台的部署，行为应保持一致；对于反向代理、HTTPS 入口、内网 IP 或不同访问 origin 的部署，该修改可以减少前端请求失败。