### PR TITLE
使用相对 URL 处理文章批量操作

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -737,15 +737,15 @@ class ArticleController extends Controller
     {
         if ($isTrashView) {
             return [
-                'batch_restore' => route('admin.articles.batch.restore'),
-                'batch_force_delete' => route('admin.articles.batch.force-delete'),
+                'batch_restore' => route('admin.articles.batch.restore', [], false),
+                'batch_force_delete' => route('admin.articles.batch.force-delete', [], false),
             ];
         }
 
         return [
-            'batch_update_status' => route('admin.articles.batch.update-status'),
-            'batch_update_review' => route('admin.articles.batch.update-review'),
-            'delete_articles' => route('admin.articles.batch.delete'),
+            'batch_update_status' => route('admin.articles.batch.update-status', [], false),
+            'batch_update_review' => route('admin.articles.batch.update-review', [], false),
+            'delete_articles' => route('admin.articles.batch.delete', [], false),
         ];
     }
 }

--- a/resources/views/admin/articles/index.blade.php
+++ b/resources/views/admin/articles/index.blade.php
@@ -279,7 +279,7 @@
                 </div>
             @else
                 <div id="batch-actions" class="hidden px-6 py-3 bg-gray-50 border-b border-gray-200">
-                    <form method="POST" action="{{ route('admin.articles.batch.update-status') }}" id="batch-form">
+                    <form method="POST" action="{{ route('admin.articles.batch.update-status', [], false) }}" id="batch-form">
                         @csrf
                         <div id="batch-selected-ids"></div>
                         <div class="flex items-center space-x-4">

--- a/resources/views/admin/articles/index.blade.php
+++ b/resources/views/admin/articles/index.blade.php
@@ -528,7 +528,7 @@
         const ARTICLES_I18N = @json($articlesI18n);
         const TRASH_I18N = @json($trashI18n);
         const IS_TRASH_VIEW = @json($isTrashView);
-        const EMPTY_TRASH_URL = @json(route('admin.articles.trash.empty'));
+        const EMPTY_TRASH_URL = @json(route('admin.articles.trash.empty', [], false));
 
         function toggleBatchActions() {
             const batchActions = document.getElementById('batch-actions');


### PR DESCRIPTION
## 背景

我们在生产环境中遇到一个问题：在后台文章列表页正常勾选文章、选择“发布状态”并执行批量操作后，页面会跳转到：

`/geo_admin/articles/batch/update-status`

并返回 `405 Method Not Allowed`。

排查后发现，该路由本身只接受 `POST` 请求，这是正确的；但在某些反向代理、Cloudflare Tunnel、HTTPS 终止或访问 origin 与 `APP_URL` 不完全一致的部署场景下，页面内生成的绝对 URL 可能引发跳转或重定向，导致原本的表单提交最终以 `GET` 方式访问 POST-only 路由。

## 修改内容

将文章批量操作相关的后台 URL 改为相对路径：

- 文章批量修改发布状态
- 文章批量修改审核状态
- 文章批量删除
- 回收站批量恢复
- 回收站批量强制删除

具体做法是使用 Laravel 的相对 URL 生成方式：

```php
route('...', [], false)
```

## 为什么这样改

这些操作都是当前后台页面内的同源表单/AJAX 请求，本身不需要依赖绝对 URL。

这个修改不会替代正确的 `APP_URL` / 代理配置；`APP_URL` 仍然应该用于 CLI、队列任务、邮件、外部链接等需要绝对 URL 的场景。

改为相对 URL 后，后台页面内的批量操作会跟随当前页面 origin，能降低反向代理、Cloudflare Tunnel、HTTPS 终止、内网 IP/域名混用等部署场景下的前端提交风险。

## 安全影响

本次修改不改变后端安全边界：

- 不改变路由定义
- 不改变 HTTP method
- 不改变 controller 逻辑
- 不改变请求参数
- 不改变 admin middleware / auth
- 不改变 CSRF 保护

相关批量操作仍然是受保护的后台 POST 请求。

## 测试

已在生产部署中验证：

- 后台文章列表页勾选文章后，批量修改发布状态可正常执行
- `POST /geo_admin/articles/batch/update-status` 仍受 CSRF 保护
- `GET /geo_admin/articles/batch/update-status` 仍返回 `405 Method Not Allowed`，符合预期
- 首页和后台登录页正常返回 `200`
- app/web/postgres/redis 容器 healthy，queue/scheduler/reverb 正常运行
- `php artisan queue:failed` 无失败任务