### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/resources/views/admin/ai-models/index.blade.php
+++ b/resources/views/admin/ai-models/index.blade.php
@@ -224,6 +224,7 @@
                         <label class="block text-sm font-medium text-gray-700 mb-2">{{ __('admin.ai_models.quick_chat') }}</label>
                         <div class="flex flex-wrap gap-2">
                             <button type="button" onclick="fillPreset('minimax')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">MiniMax</button>
+                            <button type="button" onclick="fillPreset('minimax_m27')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">MiniMax M2.7</button>
                             <button type="button" onclick="fillPreset('minimax_highspeed')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">MiniMax Highspeed</button>
                             <button type="button" onclick="fillPreset('openai')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">OpenAI</button>
                             <button type="button" onclick="fillPreset('gemini')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">Gemini</button>
@@ -333,7 +334,8 @@
         const TEST_URL_TEMPLATE = @json(route('admin.ai-models.test', ['modelId' => '__MODEL_ID__'], false));
 
         const PROVIDER_PRESETS = {
-            minimax: {name: 'MiniMax M2.7', version: 'M2.7', model_id: 'MiniMax-M2.7', api_url: 'https://api.minimax.io', model_type: 'chat'},
+            minimax: {name: 'MiniMax M3', version: 'M3', model_id: 'MiniMax-M3', api_url: 'https://api.minimax.io', model_type: 'chat'},
+            minimax_m27: {name: 'MiniMax M2.7', version: 'M2.7', model_id: 'MiniMax-M2.7', api_url: 'https://api.minimax.io', model_type: 'chat'},
             minimax_highspeed: {name: 'MiniMax M2.7 Highspeed', version: 'M2.7', model_id: 'MiniMax-M2.7-highspeed', api_url: 'https://api.minimax.io', model_type: 'chat'},
             openai: {name: 'GPT-4o', version: '', model_id: 'gpt-4o', api_url: 'https://api.openai.com', model_type: 'chat'},
             gemini: {name: 'Gemini 3 Flash Preview', version: 'v1beta', model_id: 'gemini-3-flash-preview', api_url: 'https://generativelanguage.googleapis.com/v1beta', model_type: 'chat'},

--- a/tests/Unit/OpenAiRuntimeProviderTest.php
+++ b/tests/Unit/OpenAiRuntimeProviderTest.php
@@ -163,7 +163,7 @@ class OpenAiRuntimeProviderTest extends TestCase
 
     public function test_it_resolves_chat_driver_for_minimax(): void
     {
-        $this->assertSame('deepseek', OpenAiRuntimeProvider::resolveChatDriver('https://api.minimaxi.com/v1', 'MiniMax-M2.7'));
+        $this->assertSame('deepseek', OpenAiRuntimeProvider::resolveChatDriver('https://api.minimaxi.com/v1', 'MiniMax-M3'));
     }
 
     public function test_it_resolves_chat_driver_for_siliconflow(): void


### PR DESCRIPTION
## Summary
Upgrade the MiniMax quick-fill preset on the AI Models admin page to use the latest **MiniMax-M3** model as the default, while preserving M2.7 and the Highspeed variant as alternatives.

## Changes
- `resources/views/admin/ai-models/index.blade.php`
  - `minimax` preset (the "MiniMax" quick button) now points to `MiniMax-M3` (`api.minimax.io`, chat model)
  - New `minimax_m27` preset and "MiniMax M2.7" button added so existing users can still pick the previous default in one click
  - `minimax_highspeed` preset (`MiniMax-M2.7-highspeed`) retained unchanged
- `tests/Unit/OpenAiRuntimeProviderTest.php`
  - `test_it_resolves_chat_driver_for_minimax` updated to assert driver resolution against `MiniMax-M3`; the URL-based driver decision (`https://api.minimaxi.com/v1` -> `deepseek` driver) is unchanged

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Setting it as the default makes new GEOFlow installations pick the newer model out-of-the-box, while keeping M2.7 / Highspeed available for users who prefer the older generation.

## Testing
- `php -l` passes for both modified files
- Diff is minimal (2 files, +4/-2); no API URL or other provider configuration changed