### PR TITLE
修复火山方舟等 OpenAI 兼容向量模型同步：去掉 dimensions 参数

### DIFF
--- a/app/Services/GeoFlow/KnowledgeChunkSyncService.php
+++ b/app/Services/GeoFlow/KnowledgeChunkSyncService.php
@@ -10,6 +10,7 @@ use App\Models\SiteSetting;
 use App\Support\GeoFlow\ApiKeyCrypto;
 use App\Support\GeoFlow\OpenAiRuntimeProvider;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Embeddings;
@@ -876,10 +877,12 @@ class KnowledgeChunkSyncService
         );
 
         try {
-            $response = Embeddings::for([$this->formatEmbeddingQueryInput($query, $embeddingMetadata)])
-                ->timeout(45)
-                ->generate($providerName, (string) $embeddingMetadata['model_name']);
-            $rawVector = $this->normalizeEmbeddingVector($response->embeddings[0] ?? null);
+            $embeddings = $this->requestEmbeddingVectors(
+                [$this->formatEmbeddingQueryInput($query, $embeddingMetadata)],
+                $embeddingMetadata,
+                $providerName
+            );
+            $rawVector = $this->normalizeEmbeddingVector($embeddings[0] ?? null);
             if ($rawVector === null) {
                 return [];
             }
@@ -1069,12 +1072,9 @@ class KnowledgeChunkSyncService
     ): array {
         $batchKeys = array_keys($batch);
         $batchInputs = $this->formatEmbeddingDocumentInputs(array_values($batch), $embeddingMetadata, $documentTitle);
-        $response = Embeddings::for($batchInputs)
-            ->timeout(45)
-            ->generate($providerName, (string) $embeddingMetadata['model_name']);
+        $embeddings = $this->requestEmbeddingVectors($batchInputs, $embeddingMetadata, $providerName);
 
         $results = [];
-        $embeddings = $response->embeddings;
         foreach (array_values($batch) as $position => $_chunkContent) {
             $rawVector = $this->normalizeEmbeddingVector($embeddings[$position] ?? null);
             if ($rawVector === null) {
@@ -1102,6 +1102,74 @@ class KnowledgeChunkSyncService
 
         return str_contains($normalized, 'batch size')
             || str_contains($normalized, 'batch_size');
+    }
+
+    /**
+     * 生成一批文本对应的真实 embedding 向量。
+     *
+     * OpenAI 兼容服务商（OpenAI / 火山方舟 Doubao / MiniMax / 智谱 等）统一走直连 /embeddings 请求，
+     * 仅发送 model + input；不再附带 Laravel AI 默认注入的 dimensions 参数，避免部分服务商
+     * （如 doubao-embedding-text）将其判定为 InvalidParameter 而导致整批向量化失败。
+     * Gemini 原生接口形态不同，继续复用 SDK。
+     *
+     * @param  list<string>  $inputs
+     * @param  array{model_id:int,model_name:string,provider:string,api_url:string,api_key:string,driver:string}  $embeddingMetadata
+     * @return list<mixed>  与 $inputs 顺序对应的原始向量数组
+     */
+    private function requestEmbeddingVectors(array $inputs, array $embeddingMetadata, string $providerName): array
+    {
+        if ($this->isGeminiEmbeddingMetadata($embeddingMetadata)) {
+            $response = Embeddings::for($inputs)
+                ->timeout(45)
+                ->generate($providerName, (string) $embeddingMetadata['model_name']);
+
+            return array_values((array) $response->embeddings);
+        }
+
+        return $this->requestOpenAiCompatibleEmbeddings($inputs, $embeddingMetadata);
+    }
+
+    /**
+     * 直连 OpenAI 兼容 /embeddings 接口，仅发送 model + input。
+     *
+     * 出站代理由全局 {@see \App\Support\GeoFlow\OutboundHttpProxy} 中间件按域名注入，无需在此重复配置。
+     *
+     * @param  list<string>  $inputs
+     * @param  array{model_id:int,model_name:string,provider:string,api_url:string,api_key:string,driver:string}  $embeddingMetadata
+     * @return list<mixed>
+     */
+    private function requestOpenAiCompatibleEmbeddings(array $inputs, array $embeddingMetadata): array
+    {
+        $endpoint = rtrim((string) $embeddingMetadata['api_url'], '/').'/embeddings';
+
+        $response = Http::acceptJson()
+            ->asJson()
+            ->withToken((string) $embeddingMetadata['api_key'])
+            ->timeout(45)
+            ->post($endpoint, [
+                'model' => (string) $embeddingMetadata['model_name'],
+                'input' => $inputs,
+            ]);
+
+        if (! $response->successful()) {
+            // 保留服务商原始报文，使 batch size 等可识别错误仍能命中后续降级逻辑。
+            throw new \RuntimeException(sprintf(
+                'HTTP request returned status code %d: %s',
+                $response->status(),
+                trim($response->body())
+            ));
+        }
+
+        $data = $response->json();
+        $rows = is_array($data) ? ($data['data'] ?? []) : [];
+        if (! is_array($rows)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn ($row): mixed => is_array($row) ? ($row['embedding'] ?? null) : null,
+            $rows
+        ));
     }
 
     private function embeddingBatchSize(): int

--- a/tests/Feature/KnowledgeChunkEmbeddingSyncTest.php
+++ b/tests/Feature/KnowledgeChunkEmbeddingSyncTest.php
@@ -688,7 +688,60 @@ class KnowledgeChunkEmbeddingSyncTest extends TestCase
         Http::assertSent(fn ($request): bool => $request->url() === 'https://ark.cn-beijing.volces.com/api/v3/embeddings'
             && $request->hasHeader('Authorization', 'Bearer test-api-key')
             && $request['model'] === 'doubao-embedding-text-240515'
-            && ($request['input'][0] ?? '') === 'GEOFlow 支持火山方舟 Doubao Embedding，适合国内环境下的知识库向量化。');
+            && ($request['input'][0] ?? '') === 'GEOFlow 支持火山方舟 Doubao Embedding，适合国内环境下的知识库向量化。'
+            && ! array_key_exists('dimensions', (array) $request->data()));
+    }
+
+    public function test_sync_omits_dimensions_parameter_for_openai_compatible_embedding(): void
+    {
+        Http::fake([
+            'https://ark.cn-beijing.volces.com/api/v3/embeddings' => function ($request) {
+                // 模拟 doubao-embedding-text 对 dimensions 参数返回 InvalidParameter，
+                // 验证我们的请求体不含该字段，从而不会触发该 400。
+                if (array_key_exists('dimensions', (array) $request->data())) {
+                    return Http::response([
+                        'error' => [
+                            'code' => 'InvalidParameter',
+                            'message' => 'One or more parameters specified in the request are not valid.',
+                        ],
+                    ], 400);
+                }
+
+                return Http::response([
+                    'data' => [
+                        ['embedding' => [0.51, 0.52, 0.53]],
+                    ],
+                ]);
+            },
+        ]);
+
+        $model = $this->createEmbeddingModel([
+            'name' => 'Doubao Embedding',
+            'model_id' => 'doubao-embedding-text-240515',
+            'api_url' => 'https://ark.cn-beijing.volces.com/api/v3',
+        ]);
+        $knowledgeBase = KnowledgeBase::query()->create([
+            'name' => 'Doubao 维度参数知识库',
+            'description' => '',
+            'content' => '',
+            'character_count' => 0,
+            'file_type' => 'markdown',
+            'word_count' => 0,
+        ]);
+
+        app(KnowledgeChunkSyncService::class)->sync(
+            (int) $knowledgeBase->id,
+            'GEOFlow 校验 Doubao Embedding 不发送 dimensions 参数。',
+            true
+        );
+
+        $chunk = $knowledgeBase->chunks()->firstOrFail();
+
+        $this->assertSame((int) $model->id, (int) $chunk->embedding_model_id);
+        $this->assertSame([0.51, 0.52, 0.53], json_decode((string) $chunk->embedding_json, true));
+
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://ark.cn-beijing.volces.com/api/v3/embeddings'
+            && ! array_key_exists('dimensions', (array) $request->data()));
     }
 
     public function test_sync_splits_embedding_requests_into_configured_batch_size(): void


### PR DESCRIPTION
## 问题

使用火山方舟 Doubao（`doubao-embedding-text`）等 OpenAI 兼容向量模型同步知识库切片时，整批向量化会失败。

根因是 Laravel AI 的 `Embeddings` 客户端默认会注入 `dimensions` 参数，而部分服务商（如 doubao-embedding-text）不接受该参数，会返回 `InvalidParameter`（HTTP 400），导致整批切片向量化失败。

## 改动

- 新增 `requestEmbeddingVectors()`：OpenAI 兼容服务商（OpenAI / 火山方舟 Doubao / MiniMax / 智谱 等）统一走直连 `/embeddings` 请求，请求体仅发送 `model` + `input`，不再附带 `dimensions`。
- Gemini 原生接口形态不同，继续复用 Laravel AI SDK。
- 直连请求保留服务商原始报文，使 batch size 等可识别错误仍能命中既有的降级重试逻辑。
- 出站代理仍由全局 `OutboundHttpProxy` 中间件按域名注入，无需重复配置。

涉及文件：
- `app/Services/GeoFlow/KnowledgeChunkSyncService.php`

## 测试

- 新增 `test_sync_omits_dimensions_parameter_for_openai_compatible_embedding`：模拟 Doubao 对 `dimensions` 返回 400，断言请求体不含该字段且向量正确落库。
- 增强既有 Doubao 用例，断言不发送 `dimensions`。
- `php artisan test --filter=KnowledgeChunkEmbeddingSyncTest`：20 passed (137 assertions)。