### PR TITLE
避免知识库证据编号出现在最终文章正文

### DIFF
--- a/app/Services/GeoFlow/WorkerExecutionService.php
+++ b/app/Services/GeoFlow/WorkerExecutionService.php
@@ -604,10 +604,10 @@ class WorkerExecutionService
         }
 
         if ($this->isLikelyEnglishPrompt($prompt)) {
-            return 'Knowledge citation rule: when using facts, data, or business judgments from the reference knowledge, cite the evidence ID such as [K1] in the relevant sentence. If the evidence is insufficient, use cautious wording and do not invent sources or conclusions.';
+            return 'Knowledge citation rule: use the reference knowledge to ground facts, data, and business judgments, but do not output evidence IDs such as [K1] in the final article. If the evidence is insufficient, use cautious wording and do not invent sources or conclusions.';
         }
 
-        return '知识库引用要求：涉及事实、数据或业务判断时，优先依据参考知识中的 [K1] 等证据编号，并在相关句子后标注证据编号；证据不足时不要编造来源或结论。';
+        return '知识库引用要求：请吸收参考知识中的证据内容来支撑事实、数据和业务判断，但最终正文不要输出 [K1]、[K2] 等证据编号；证据不足时不要编造来源或结论。';
     }
 
     private function isLikelyEnglishPrompt(string $prompt): bool

--- a/tests/Unit/WorkerExecutionServicePromptTest.php
+++ b/tests/Unit/WorkerExecutionServicePromptTest.php
@@ -66,7 +66,7 @@ class WorkerExecutionServicePromptTest extends TestCase
 
         $this->assertStringContainsString('【证据 K1】', $prompt);
         $this->assertStringContainsString('知识库引用要求', $prompt);
-        $this->assertStringContainsString('[K1]', $prompt);
+        $this->assertStringContainsString('最终正文不要输出 [K1]、[K2] 等证据编号', $prompt);
         $this->assertStringContainsString('证据不足时不要编造来源或结论', $prompt);
     }
 


### PR DESCRIPTION
## 问题

任务绑定知识库生成文章时，系统会把检索到的知识片段编号为 `K1`、`K2`、`K3` 等，并在提示词中要求模型在相关句子后标注 `[K1]` 这类证据编号。

这有利于生成过程中的事实约束，但对普通读者来说，最终正文里出现 `[K3]`、`[K5]` 会像未替换的占位符，影响文章可读性。

## 改动

- 保留知识库证据上下文供模型参考。
- 修改知识库引用指令：要求模型吸收证据内容支撑事实、数据和业务判断，但不要在最终正文输出 `[K1]`、`[K2]` 等证据编号。
- 同步调整英文提示。
- 更新 `WorkerExecutionServicePromptTest` 断言，覆盖新的提示词要求。

## 测试

- `php artisan test tests/Unit/WorkerExecutionServicePromptTest.php`
  - 5 passed (20 assertions)