### PR TITLE
Fix already-authenticated admins being redirected to the public site

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -55,6 +55,11 @@ return Application::configure(basePath: dirname(__DIR__))
             // Blade 后台：写操作日志
             'admin.activity' => LogAdminActivity::class,
         ]);
+
+        // 已登录的管理员访问登录页(guest:admin)时，重定向到后台仪表盘，而不是 Laravel 默认的 "/"。
+        // 默认逻辑只认名为 dashboard/home 的路由，本项目是 admin.dashboard/site.home，匹配不到就回落到 "/"，
+        // 导致“已登录后再打开登录页”被弹到前台内容站。这里显式指向后台首页。
+        $middleware->redirectUsersTo(fn () => route('admin.dashboard'));
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         /**

--- a/tests/Feature/AdminGuestRedirectTest.php
+++ b/tests/Feature/AdminGuestRedirectTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminGuestRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_admin_is_redirected_from_login_to_dashboard(): void
+    {
+        $admin = Admin::query()->create([
+            'username' => 'redirect_admin',
+            'password' => 'password',
+            'email' => 'redirect_admin@example.com',
+            'display_name' => 'Redirect Admin',
+            'role' => 'super_admin',
+            'status' => 'active',
+            'last_login' => null,
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->get(route('admin.login'))
+            ->assertRedirect(route('admin.dashboard'));
+    }
+
+    public function test_authenticated_admin_entry_redirects_to_dashboard(): void
+    {
+        $admin = Admin::query()->create([
+            'username' => 'entry_redirect_admin',
+            'password' => 'password',
+            'email' => 'entry_redirect_admin@example.com',
+            'display_name' => 'Entry Redirect Admin',
+            'role' => 'super_admin',
+            'status' => 'active',
+            'last_login' => null,
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->get(route('admin.entry'))
+            ->assertRedirect(route('admin.dashboard'));
+    }
+
+    public function test_guest_admin_login_flow_is_unchanged(): void
+    {
+        $this->get(route('admin.login'))
+            ->assertOk();
+
+        $this->get(route('admin.entry'))
+            ->assertRedirect(route('admin.login'));
+    }
+}


### PR DESCRIPTION
## Problem
The admin login route's `guest:admin` middleware uses Laravel's default `RedirectIfAuthenticated`, which only resolves routes literally named `dashboard` or `home`. This app names them `admin.dashboard` / `site.home`, so the matcher falls through to `/`.

As a result, an **already-authenticated** admin opening `/geo_admin/login` (or `/geo_admin`) was redirected to `/` — the **public content site** — instead of the admin panel. The confusing symptom: the same URL showed the login form in a logged-out browser but bounced to the public site in a logged-in one.

## Fix
Point the guest redirect at `admin.dashboard` via `redirectUsersTo()` in `bootstrap/app.php`, so authenticated admins land on the dashboard (matching the intent already present in `AdminAuthController::showLoginForm` and the `/geo_admin` entry route).

## Verification (curl inside the app container)
- Authed `GET /geo_admin/login` → `302 → /geo_admin/dashboard` (was `→ /`)
- Authed `GET /geo_admin` → `302 → /geo_admin/dashboard`
- Logged-out `GET /geo_admin/login` → `200` login form (no regression)
- Logged-out `GET /geo_admin` → `302 → /geo_admin/login` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)