### PR TITLE
fix: 修复二级目录部署下后台 JS 请求路径丢失前缀

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -737,15 +737,15 @@ class ArticleController extends Controller
     {
         if ($isTrashView) {
             return [
-                'batch_restore' => route('admin.articles.batch.restore', [], false),
-                'batch_force_delete' => route('admin.articles.batch.force-delete', [], false),
+                'batch_restore' => route('admin.articles.batch.restore', []),
+                'batch_force_delete' => route('admin.articles.batch.force-delete', []),
             ];
         }
 
         return [
-            'batch_update_status' => route('admin.articles.batch.update-status', [], false),
-            'batch_update_review' => route('admin.articles.batch.update-review', [], false),
-            'delete_articles' => route('admin.articles.batch.delete', [], false),
+            'batch_update_status' => route('admin.articles.batch.update-status', []),
+            'batch_update_review' => route('admin.articles.batch.update-review', []),
+            'delete_articles' => route('admin.articles.batch.delete', []),
         ];
     }
 }

--- a/app/Services/Admin/AdminWelcomeModalService.php
+++ b/app/Services/Admin/AdminWelcomeModalService.php
@@ -33,7 +33,7 @@ class AdminWelcomeModalService
             'state' => [
                 'mode' => $welcomeState['mode'] ?? 'intro',
                 'shouldAutoOpen' => $shouldAutoOpen,
-                'dismissUrl' => route('admin.welcome.dismiss', [], false),
+                'dismissUrl' => route('admin.welcome.dismiss', []),
                 'csrfToken' => csrf_token(),
                 'links' => [
                     'x' => 'https://x.com/yaojingang',

--- a/resources/views/admin/ai-models/index.blade.php
+++ b/resources/views/admin/ai-models/index.blade.php
@@ -336,9 +336,9 @@
             testNetworkError: @json(__('admin.ai_models.test_network_error')),
         };
         const SUPPORTS_MODEL_MAX_TOKENS = @json((bool) ($supportsModelMaxTokens ?? false));
-        const UPDATE_URL_TEMPLATE = @json(route('admin.ai-models.update', ['modelId' => '__MODEL_ID__'], false));
-        const DELETE_URL_TEMPLATE = @json(route('admin.ai-models.delete', ['modelId' => '__MODEL_ID__'], false));
-        const TEST_URL_TEMPLATE = @json(route('admin.ai-models.test', ['modelId' => '__MODEL_ID__'], false));
+        const UPDATE_URL_TEMPLATE = @json(route('admin.ai-models.update', ['modelId' => '__MODEL_ID__']));
+        const DELETE_URL_TEMPLATE = @json(route('admin.ai-models.delete', ['modelId' => '__MODEL_ID__']));
+        const TEST_URL_TEMPLATE = @json(route('admin.ai-models.test', ['modelId' => '__MODEL_ID__']));
 
         const PROVIDER_PRESETS = {
             minimax: {name: 'MiniMax M3', version: 'M3', model_id: 'MiniMax-M3', api_url: 'https://api.minimax.io', model_type: 'chat'},

--- a/resources/views/admin/articles/form.blade.php
+++ b/resources/views/admin/articles/form.blade.php
@@ -6,9 +6,9 @@
         ? route('admin.articles.update', ['articleId' => (int) $articleId])
         : route('admin.articles.store');
     $articleImageUploadUrl = $isEdit
-        ? route('admin.articles.editor.images.upload', ['articleId' => (int) $articleId], false)
+        ? route('admin.articles.editor.images.upload', ['articleId' => (int) $articleId])
         : '';
-    $articleWechatHtmlUrl = route('admin.articles.editor.wechat-html', [], false);
+    $articleWechatHtmlUrl = route('admin.articles.editor.wechat-html', []);
     $vditorLocaleMap = [
         'zh_CN' => 'zh_CN',
         'en' => 'en_US',

--- a/resources/views/admin/articles/index.blade.php
+++ b/resources/views/admin/articles/index.blade.php
@@ -279,7 +279,7 @@
                 </div>
             @else
                 <div id="batch-actions" class="hidden px-6 py-3 bg-gray-50 border-b border-gray-200">
-                    <form method="POST" action="{{ route('admin.articles.batch.update-status', [], false) }}" id="batch-form">
+                    <form method="POST" action="{{ route('admin.articles.batch.update-status', []) }}" id="batch-form">
                         @csrf
                         <div id="batch-selected-ids"></div>
                         <div class="flex items-center space-x-4">
@@ -528,7 +528,7 @@
         const ARTICLES_I18N = @json($articlesI18n);
         const TRASH_I18N = @json($trashI18n);
         const IS_TRASH_VIEW = @json($isTrashView);
-        const EMPTY_TRASH_URL = @json(route('admin.articles.trash.empty', [], false));
+        const EMPTY_TRASH_URL = @json(route('admin.articles.trash.empty', []));
 
         function toggleBatchActions() {
             const batchActions = document.getElementById('batch-actions');

--- a/resources/views/admin/partials/header.blade.php
+++ b/resources/views/admin/partials/header.blade.php
@@ -16,7 +16,7 @@
     $changelogLinks = is_array($updateLinks['changelog'] ?? null) ? $updateLinks['changelog'] : [];
     $notificationChangelogUrl = (string) ($changelogLinks[$localeForChangelog] ?? $changelogLinks['zh-CN'] ?? 'https://github.com/yaojingang/GEOFlow/blob/main/docs/CHANGELOG.md');
     $notificationGithubUrl = (string) ($updateLinks['github'] ?? 'https://github.com/yaojingang/GEOFlow');
-    $notificationUpdateCenterUrl = $isUpdateCenterEnabled && $isSuperAdmin ? route('admin.system-updates.index', [], false) : '';
+    $notificationUpdateCenterUrl = $isUpdateCenterEnabled && $isSuperAdmin ? route('admin.system-updates.index', []) : '';
     $notificationStatus = (string) ($updateState['status'] ?? 'disabled');
     $menu = [
         'dashboard' => ['route' => 'admin.dashboard', 'name' => __('admin.nav.dashboard')],

--- a/resources/views/admin/system-updates/index.blade.php
+++ b/resources/views/admin/system-updates/index.blade.php
@@ -452,7 +452,7 @@
                     </span>
                 </div>
             </div>
-            <div id="system-update-runs" data-status-url="{{ route('admin.system-updates.runs.status', [], false) }}" data-has-active-run="{{ $hasActiveUpdateRun ? '1' : '0' }}">
+            <div id="system-update-runs" data-status-url="{{ route('admin.system-updates.runs.status', []) }}" data-has-active-run="{{ $hasActiveUpdateRun ? '1' : '0' }}">
                 @include('admin.system-updates.partials.recent-runs', ['recentRuns' => $recentRuns])
             </div>
         </section>

--- a/resources/views/admin/tasks/index.blade.php
+++ b/resources/views/admin/tasks/index.blade.php
@@ -401,8 +401,8 @@
 <script>
 const TASK_I18N = @json($taskI18n, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
 const TASK_REALTIME = @json($taskRealtime, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
-const TASK_HEALTH_URL = @js(route('admin.tasks.health', [], false));
-const TASK_BATCH_URL = @js(route('admin.tasks.batch', [], false));
+const TASK_HEALTH_URL = @js(route('admin.tasks.health', []));
+const TASK_BATCH_URL = @js(route('admin.tasks.batch', []));
 const TASK_INITIAL_OVERVIEW = @json($taskInitialOverview, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
 const TASK_TEXT = {
     workerNone: @js(__('admin.tasks.worker.none')),

--- a/resources/views/admin/url-import/show.blade.php
+++ b/resources/views/admin/url-import/show.blade.php
@@ -33,8 +33,8 @@
         data-status="{{ $job->status }}"
         data-has-result="{{ $result !== [] ? '1' : '0' }}"
         data-autostart="{{ $job->status === 'queued' ? '1' : '0' }}"
-        data-run-url="{{ route('admin.url-import.run', ['jobId' => $job->id], false) }}"
-        data-status-url="{{ route('admin.url-import.status', ['jobId' => $job->id], false) }}"
+        data-run-url="{{ route('admin.url-import.run', ['jobId' => $job->id]) }}"
+        data-status-url="{{ route('admin.url-import.status', ['jobId' => $job->id]) }}"
         data-ai-config-url="{{ route('admin.ai-models.index') }}"
     >
         <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">

--- a/tests/Feature/AdminArticlesPageTest.php
+++ b/tests/Feature/AdminArticlesPageTest.php
@@ -100,7 +100,7 @@ class AdminArticlesPageTest extends TestCase
             ->assertSee('vendor/vditor/dist/index.min.js', false)
             ->assertSee('vendor/cropperjs/cropper.min.js', false)
             ->assertSee(route('admin.articles.editor.images.upload', ['articleId' => (int) $article->id], false), false)
-            ->assertSee(route('admin.articles.editor.wechat-html', [], false), false)
+            ->assertSee(route('admin.articles.editor.wechat-html', []), false)
             ->assertSee('id="content-editor"', false)
             ->assertSee('id="article-editor-copy-markdown"', false)
             ->assertSee('id="article-editor-copy-wechat-html"', false)
@@ -396,9 +396,9 @@ class AdminArticlesPageTest extends TestCase
             ->getContent();
 
         foreach ([
-            route('admin.articles.batch.update-status', [], false),
-            route('admin.articles.batch.update-review', [], false),
-            route('admin.articles.batch.delete', [], false),
+            route('admin.articles.batch.update-status', []),
+            route('admin.articles.batch.update-review', []),
+            route('admin.articles.batch.delete', []),
         ] as $path) {
             $escapedPath = str_replace('/', '\\/', $path);
 
@@ -407,7 +407,7 @@ class AdminArticlesPageTest extends TestCase
             $this->assertStringNotContainsString('https:\/\/configured.example'.$escapedPath, $listHtml);
         }
         $this->assertStringContainsString(
-            'action="'.route('admin.articles.batch.update-status', [], false).'"',
+            'action="'.route('admin.articles.batch.update-status', []).'"',
             $listHtml
         );
 
@@ -419,9 +419,9 @@ class AdminArticlesPageTest extends TestCase
             ->getContent();
 
         foreach ([
-            route('admin.articles.batch.restore', [], false),
-            route('admin.articles.batch.force-delete', [], false),
-            route('admin.articles.trash.empty', [], false),
+            route('admin.articles.batch.restore', []),
+            route('admin.articles.batch.force-delete', []),
+            route('admin.articles.trash.empty', []),
         ] as $path) {
             $escapedPath = str_replace('/', '\\/', $path);
 

--- a/tests/Feature/AdminDashboardQuickStartTest.php
+++ b/tests/Feature/AdminDashboardQuickStartTest.php
@@ -122,7 +122,7 @@ class AdminDashboardQuickStartTest extends TestCase
         $response = $this->actingAs($admin, 'admin')
             ->get(route('admin.dashboard'));
 
-        $dismissPath = route('admin.welcome.dismiss', [], false);
+        $dismissPath = route('admin.welcome.dismiss', []);
         $escapedDismissPath = str_replace('/', '\\/', $dismissPath);
         $html = $response->getContent();
 

--- a/tests/Feature/AdminSystemUpdatesPageTest.php
+++ b/tests/Feature/AdminSystemUpdatesPageTest.php
@@ -59,7 +59,7 @@ class AdminSystemUpdatesPageTest extends TestCase
         $this->actingAs($admin, 'admin')
             ->get(route('admin.dashboard'))
             ->assertOk()
-            ->assertSee(route('admin.system-updates.index', [], false), false);
+            ->assertSee(route('admin.system-updates.index', []), false);
 
         $this->actingAs($admin, 'admin')
             ->get(route('admin.system-updates.index'))
@@ -100,7 +100,7 @@ class AdminSystemUpdatesPageTest extends TestCase
         $response
             ->assertOk()
             ->assertSee(__('admin.system_updates.plan_status.ready'))
-            ->assertSee(route('admin.system-updates.plan', [], false), false)
+            ->assertSee(route('admin.system-updates.plan', []), false)
             ->assertSee('可以生成计划的更新摘要');
 
         $summary = app(\App\Services\Admin\SystemUpdateStateService::class)->summary();
@@ -163,7 +163,7 @@ class AdminSystemUpdatesPageTest extends TestCase
         $this->actingAs($admin, 'admin')
             ->get(route('admin.dashboard'))
             ->assertOk()
-            ->assertDontSee(route('admin.system-updates.index', [], false), false);
+            ->assertDontSee(route('admin.system-updates.index', []), false);
 
         $this->actingAs($admin, 'admin')
             ->get(route('admin.system-updates.index'))
@@ -194,7 +194,7 @@ class AdminSystemUpdatesPageTest extends TestCase
         $this->actingAs($admin, 'admin')
             ->get(route('admin.dashboard'))
             ->assertOk()
-            ->assertDontSee(route('admin.system-updates.index', [], false), false);
+            ->assertDontSee(route('admin.system-updates.index', []), false);
 
         $this->actingAs($admin, 'admin')
             ->get(route('admin.system-updates.index'))


### PR DESCRIPTION
## Summary

- 移除后台 Blade/JS 中 `route(..., false)` 的相对路径模式，改为默认生成绝对 URL
- 修复应用在二级目录（如 `/doc`）部署时，测试/编辑/删除等 `fetch` 与动态表单提交落到站点根路径（如 `/geo_admin/...` 而非 `/doc/geo_admin/...`）的问题
- 同步更新相关 Feature 测试中的 `route()` 调用

## Background

Laravel 的 `route($name, $params, false)` 会主动剥离 `X-Forwarded-Prefix`（`request()->getBaseUrl()`），在反向代理二级目录场景下不适合用于 `fetch()` 或以 `/` 开头的表单 `action`。在已配置 `TRUSTED_PROXIES` 与 `X-Forwarded-Prefix` 时，默认 `route()` 可正确生成带前缀的绝对地址。

## Changed areas

- AI 模型（测试 / 编辑 / 删除）
- 文章列表与编辑器（批量操作、图片上传、微信 HTML 导出）
- 任务中心（健康检查、批量启停）
- URL 导入轮询
- 系统更新状态轮询
- 顶栏更新中心链接、欢迎弹窗关闭

## Test plan

- [x] `php artisan test --filter='AdminAiModelsPageTest|AdminArticlesPageTest|AdminSystemUpdatesPageTest|AdminDashboardQuickStartTest|TrustedProxyConfigurationTest'`
- [ ] 在二级目录部署环境（`X-Forwarded-Prefix: /doc`）验证 AI 模型「测试」按钮返回正确 JSON 提示
- [ ] 验证文章批量操作、任务批量启停等 JS 请求不再 404


Made with [Cursor](https://cursor.com)