### PR TITLE
fix: preserve APP_URL subdirectory for Echo broadcasting auth

### DIFF
--- a/app/Support/AdminWeb.php
+++ b/app/Support/AdminWeb.php
@@ -44,6 +44,26 @@ final class AdminWeb
     }
 
     /**
+     * 为同源前端请求补全 APP_URL 中的二级目录前缀（如 /doc/broadcasting/auth）。
+     */
+    public static function appPath(string $path): string
+    {
+        $path = '/'.ltrim($path, '/');
+        $appPath = trim((string) (parse_url((string) config('app.url', ''), PHP_URL_PATH) ?: ''), '/');
+
+        if ($appPath === '') {
+            return $path;
+        }
+
+        $appPrefix = '/'.$appPath;
+        if ($path === $appPrefix || str_starts_with($path, $appPrefix.'/')) {
+            return $path;
+        }
+
+        return rtrim($appPrefix, '/').$path;
+    }
+
+    /**
      * Build a same-origin route path for admin JavaScript endpoints and forms.
      *
      * This keeps URLs independent from the configured APP_URL host while still

--- a/resources/js/echo.js
+++ b/resources/js/echo.js
@@ -10,6 +10,7 @@ const reverbScheme = runtimeReverb.scheme ?? 'https';
 const reverbPort = runtimeReverb.port ?? (reverbScheme === 'https' ? 443 : 80);
 const reverbKey = runtimeReverb.key;
 const reverbHost = runtimeReverb.host;
+const authEndpoint = (runtimeReverb.authEndpoint ?? '/broadcasting/auth').trim();
 
 if (!runtimeReverb.enabled || !reverbKey || !reverbHost) {
     window.Echo = null;
@@ -22,6 +23,7 @@ if (!runtimeReverb.enabled || !reverbKey || !reverbHost) {
         wssPort: reverbPort,
         forceTLS: reverbScheme === 'https',
         enabledTransports: ['ws', 'wss'],
+        authEndpoint: authEndpoint.startsWith('/') ? authEndpoint : `/${authEndpoint}`,
         auth: {
             headers: {
                 'X-CSRF-TOKEN': csrfToken,

--- a/resources/views/admin/partials/footer.blade.php
+++ b/resources/views/admin/partials/footer.blade.php
@@ -22,6 +22,7 @@
         'port' => (int) (config('reverb.apps.apps.0.options.port') ?: 443),
         'scheme' => (string) (config('reverb.apps.apps.0.options.scheme') ?: 'https'),
         'path' => rtrim($reverbPath, '/'),
+        'authEndpoint' => \App\Support\AdminWeb::appPath('/broadcasting/auth'),
     ];
 @endphp
 <footer class="bg-white border-t border-gray-200 mt-12">

--- a/tests/Unit/AdminWebAppPathTest.php
+++ b/tests/Unit/AdminWebAppPathTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\AdminWeb;
+use Tests\TestCase;
+
+class AdminWebAppPathTest extends TestCase
+{
+    public function test_app_path_respects_configured_subdirectory(): void
+    {
+        config(['app.url' => 'http://www.example.com/doc']);
+
+        $this->assertSame('/doc/broadcasting/auth', AdminWeb::appPath('/broadcasting/auth'));
+    }
+
+    public function test_app_path_without_subdirectory_stays_at_root(): void
+    {
+        config(['app.url' => 'http://www.example.com']);
+
+        $this->assertSame('/broadcasting/auth', AdminWeb::appPath('/broadcasting/auth'));
+    }
+
+    public function test_app_path_does_not_prefix_twice(): void
+    {
+        config(['app.url' => 'http://www.example.com/doc']);
+
+        $this->assertSame('/doc/broadcasting/auth', AdminWeb::appPath('/doc/broadcasting/auth'));
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `AdminWeb::appPath()`，根据 `APP_URL` 的二级目录前缀生成同源路径
- 将 Echo 的 `authEndpoint` 改为运行时注入，修复二级目录部署（如 `/doc`）下私有频道授权请求打到根路径 `/broadcasting/auth` 的问题
- 补充单元测试覆盖有/无二级目录及重复前缀场景

## Background
重构 tasks 页从直接 `new Pusher` 改为统一 `echo.js` 后，丢失了原先 Blade 中 `@js(url('/broadcasting/auth'))` 对二级目录的处理，导致 Reverb 私有频道鉴权失败。

## Test plan
- [x] `php artisan test --filter=AdminWebAppPathTest`
- [ ] 二级目录部署下打开后台任务页，确认 `window.GEOFLOW_REVERB_CONFIG.authEndpoint` 为 `/doc/broadcasting/auth`
- [ ] 确认 `/doc/broadcasting/auth` 请求返回 200，WebSocket 私有频道订阅成功


Made with [Cursor](https://cursor.com)