### PR TITLE
Fix Docker Compose quick start setup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
       POSTGRES_USER: "${DB_USERNAME:-geo_user}"
       POSTGRES_PASSWORD: "${DB_PASSWORD:-change-this-password}"
     volumes:
-      - ${POSTGRES_DATA_DIR:-./docker-data/prod/postgres}:${POSTGRES_CONTAINER_DATA_DIR:-/var/lib/postgresql/data}
+      - ${POSTGRES_DATA_DIR:-./docker-data/prod/postgres}:${POSTGRES_CONTAINER_DATA_DIR:-/var/lib/postgresql}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "127.0.0.1:${DB_EXPOSE_PORT:-15432}:5432"
     volumes:
-      - ${POSTGRES_DATA_DIR:-./docker-data/dev/postgres}:/var/lib/postgresql/data
+      - ${POSTGRES_DATA_DIR:-./docker-data/dev/postgres}:${POSTGRES_CONTAINER_DATA_DIR:-/var/lib/postgresql}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-geo_user} -d ${DB_DATABASE:-geo_flow}"]
       interval: 10s
@@ -25,6 +25,16 @@ services:
     ports:
       - "127.0.0.1:${REDIS_EXPOSE_PORT:-16379}:6379"
     restart: unless-stopped
+
+  assets:
+    image: ${NODE_IMAGE:-node:22-bookworm-slim}
+    container_name: geoflow-assets
+    working_dir: /var/www/html
+    command: ["sh", "-lc", "npm ci --include=dev --no-audit --no-fund && npm run build"]
+    volumes:
+      - ./:/var/www/html
+      - geoflow-node-modules:/var/www/html/node_modules
+    restart: "no"
 
   init:
     image: geoflow-app:latest
@@ -65,6 +75,8 @@ services:
     volumes:
       - ./:/var/www/html
     depends_on:
+      assets:
+        condition: service_completed_successfully
       init:
         condition: service_completed_successfully
     restart: unless-stopped
@@ -124,3 +136,6 @@ services:
       init:
         condition: service_completed_successfully
     restart: unless-stopped
+
+volumes:
+  geoflow-node-modules:


### PR DESCRIPTION
## Summary

Fixes two Docker Compose quick-start failures:

- Mount PostgreSQL data at `${POSTGRES_CONTAINER_DATA_DIR:-/var/lib/postgresql}` in both dev and prod Compose files so the defaults align with the PG18 image and the example env files.
- Add a one-shot `assets` service in the dev Compose file and make the app wait for it, so `public/build/manifest.json` exists before the dashboard renders.

## Root Cause

The README quick-start path uses `.env.example`, which defaults to `PGVECTOR_IMAGE=pgvector/pgvector:pg18` and `POSTGRES_CONTAINER_DATA_DIR=/var/lib/postgresql`. The dev Compose file still hardcoded the older `/var/lib/postgresql/data` target. Separately, the dev Compose path started Laravel without running the Vite production build, so authenticated dashboard requests failed with `Vite manifest not found at: /var/www/html/public/build/manifest.json`.

## Validation

- Parsed `docker-compose.yml` and `docker-compose.prod.yml` with YAML aliases enabled and checked the expected service/volume wiring.
- Ran `git diff --check`.
- Confirmed the dashboard succeeds after the Vite manifest exists.

Not run: `docker compose config`, because Docker CLI is not available in this shell.