### PR TITLE
Fix growth center migration guard

### DIFF
--- a/app/Http/Controllers/Admin/AnalyticsController.php
+++ b/app/Http/Controllers/Admin/AnalyticsController.php
@@ -107,42 +107,57 @@ class AnalyticsController extends Controller
                 ->count();
         }
 
-        $formsTotal = LeadForm::query()->count();
-        $activeForms = LeadForm::query()->where('status', LeadForm::STATUS_ACTIVE)->count();
-        $submissionsTotal = LeadSubmission::query()->count();
-        $newLeads = LeadSubmission::query()->where('status', LeadSubmission::STATUS_NEW)->count();
-        $pendingFollowups = LeadSubmission::query()
-            ->whereIn('status', [LeadSubmission::STATUS_NEW, LeadSubmission::STATUS_CONTACTED])
-            ->count();
-        $handledLeads = LeadSubmission::query()
-            ->whereIn('status', [
-                LeadSubmission::STATUS_CONTACTED,
-                LeadSubmission::STATUS_QUALIFIED,
-                LeadSubmission::STATUS_CONVERTED,
-            ])
-            ->count();
+        $leadFormsReady = Schema::hasTable('lead_forms');
+        $leadSubmissionsReady = Schema::hasTable('lead_submissions');
 
-        $recentSubmissions = LeadSubmission::query()
-            ->with('form:id,name,slug')
-            ->orderByDesc('created_at')
-            ->limit(5)
-            ->get();
+        $formsTotal = $leadFormsReady ? LeadForm::query()->count() : 0;
+        $activeForms = $leadFormsReady ? LeadForm::query()->where('status', LeadForm::STATUS_ACTIVE)->count() : 0;
+        $submissionsTotal = $leadSubmissionsReady ? LeadSubmission::query()->count() : 0;
+        $newLeads = $leadSubmissionsReady ? LeadSubmission::query()->where('status', LeadSubmission::STATUS_NEW)->count() : 0;
+        $pendingFollowups = $leadSubmissionsReady
+            ? LeadSubmission::query()
+                ->whereIn('status', [LeadSubmission::STATUS_NEW, LeadSubmission::STATUS_CONTACTED])
+                ->count()
+            : 0;
+        $handledLeads = $leadSubmissionsReady
+            ? LeadSubmission::query()
+                ->whereIn('status', [
+                    LeadSubmission::STATUS_CONTACTED,
+                    LeadSubmission::STATUS_QUALIFIED,
+                    LeadSubmission::STATUS_CONVERTED,
+                ])
+                ->count()
+            : 0;
 
-        $sourceSummary = LeadSubmission::query()
-            ->select(['source_url', 'status'])
-            ->orderByDesc('created_at')
-            ->limit(500)
-            ->get()
-            ->groupBy(fn (LeadSubmission $submission): string => trim((string) $submission->source_url) !== '' ? (string) $submission->source_url : __('admin.growth_center.direct_source'))
-            ->map(fn ($rows, string $source): array => [
-                'source' => $source,
-                'count' => $rows->count(),
-                'converted' => $rows->where('status', LeadSubmission::STATUS_CONVERTED)->count(),
-            ])
-            ->sortByDesc('count')
-            ->values()
-            ->take(6)
-            ->all();
+        $recentSubmissions = collect();
+        if ($leadSubmissionsReady) {
+            $recentSubmissionsQuery = LeadSubmission::query()
+                ->orderByDesc('created_at')
+                ->limit(5);
+            if ($leadFormsReady) {
+                $recentSubmissionsQuery->with('form:id,name,slug');
+            }
+
+            $recentSubmissions = $recentSubmissionsQuery->get();
+        }
+
+        $sourceSummary = $leadSubmissionsReady
+            ? LeadSubmission::query()
+                ->select(['source_url', 'status'])
+                ->orderByDesc('created_at')
+                ->limit(500)
+                ->get()
+                ->groupBy(fn (LeadSubmission $submission): string => trim((string) $submission->source_url) !== '' ? (string) $submission->source_url : __('admin.growth_center.direct_source'))
+                ->map(fn ($rows, string $source): array => [
+                    'source' => $source,
+                    'count' => $rows->count(),
+                    'converted' => $rows->where('status', LeadSubmission::STATUS_CONVERTED)->count(),
+                ])
+                ->sortByDesc('count')
+                ->values()
+                ->take(6)
+                ->all()
+            : [];
 
         return [
             'stats' => [

--- a/app/Http/Controllers/Admin/SiteSettingsController.php
+++ b/app/Http/Controllers/Admin/SiteSettingsController.php
@@ -14,6 +14,7 @@ use App\Support\Site\SiteSettingsBag;
 use App\Support\Site\SiteThemeCatalog;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
@@ -55,10 +56,7 @@ class SiteSettingsController extends Controller
             'homepageModuleTypes' => HomepageModuleBuilder::TYPES,
             'homepageModuleLayouts' => HomepageModuleBuilder::LAYOUTS,
             'homepageArticleSources' => HomepageModuleBuilder::ARTICLE_SOURCES,
-            'leadForms' => LeadForm::query()
-                ->where('status', LeadForm::STATUS_ACTIVE)
-                ->orderBy('name')
-                ->get(['id', 'name', 'slug']),
+            'leadForms' => $this->activeLeadForms(),
             'homepageContainerWidths' => HomepageModuleBuilder::CONTAINER_WIDTHS,
             'homepageSpacings' => HomepageModuleBuilder::SPACINGS,
             'homepageRadii' => HomepageModuleBuilder::RADII,
@@ -68,6 +66,18 @@ class SiteSettingsController extends Controller
             'articleDetailAds' => $this->parseArticleDetailAds((string) ($settings['article_detail_ads'] ?? '[]')),
             'articleDetailTextAds' => $this->parseArticleDetailTextAds((string) ($settings['article_detail_text_ads'] ?? '[]')),
         ]);
+    }
+
+    private function activeLeadForms()
+    {
+        if (! Schema::hasTable('lead_forms')) {
+            return collect();
+        }
+
+        return LeadForm::query()
+            ->where('status', LeadForm::STATUS_ACTIVE)
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug']);
     }
 
     /**

--- a/app/Http/Controllers/Site/HomeController.php
+++ b/app/Http/Controllers/Site/HomeController.php
@@ -36,11 +36,13 @@ class HomeController extends Controller
         $homepageCarouselSlides = $this->parseHomepageCarouselSlides((string) ($map['home_carousel_slides'] ?? '[]'));
         $homepageModules = HomepageModuleBuilder::fromRaw((string) ($map['homepage_modules'] ?? '[]'));
         $homepageStyle = HomepageModuleBuilder::styleFromRaw((string) ($map['homepage_style'] ?? '{}'));
-        $leadForms = LeadForm::query()
-            ->where('status', LeadForm::STATUS_ACTIVE)
-            ->orderBy('name')
-            ->get()
-            ->keyBy('slug');
+        $leadForms = Schema::hasTable('lead_forms')
+            ? LeadForm::query()
+                ->where('status', LeadForm::STATUS_ACTIVE)
+                ->orderBy('name')
+                ->get()
+                ->keyBy('slug')
+            : collect();
 
         $category = null;
         $categoryMissing = false;

--- a/tests/Feature/AdminAnalyticsPageTest.php
+++ b/tests/Feature/AdminAnalyticsPageTest.php
@@ -94,6 +94,20 @@ class AdminAnalyticsPageTest extends TestCase
         $this->assertStringContainsString('text-blue-600 font-medium', $html);
     }
 
+    public function test_analytics_page_renders_before_lead_tables_are_migrated(): void
+    {
+        Schema::dropIfExists('lead_submissions');
+        Schema::dropIfExists('lead_forms');
+
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.analytics'))
+            ->assertOk()
+            ->assertSee(__('admin.analytics.heading'))
+            ->assertSee(__('admin.growth_center.priority.no_form_title'))
+            ->assertSee(__('admin.growth_center.inbox.empty'))
+            ->assertSee(__('admin.growth_center.source.empty'));
+    }
+
     public function test_analytics_page_applies_date_filters_to_content_metrics(): void
     {
         Carbon::setTestNow(Carbon::parse('2026-05-21 12:00:00'));

--- a/tests/Feature/AdminSiteSettingsPageTest.php
+++ b/tests/Feature/AdminSiteSettingsPageTest.php
@@ -12,6 +12,7 @@ use App\Support\AdminWeb;
 use App\Support\Site\SiteThemeCatalog;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class AdminSiteSettingsPageTest extends TestCase
@@ -36,6 +37,27 @@ class AdminSiteSettingsPageTest extends TestCase
             ->assertSee(__('admin.site_settings.section_home_carousel'))
             ->assertSee(__('admin.site_settings.module_sensitive_words'))
             ->assertSee('value="'.AdminWeb::basePath().'"', false);
+    }
+
+    public function test_site_settings_page_renders_before_lead_forms_table_is_migrated(): void
+    {
+        Schema::dropIfExists('lead_submissions');
+        Schema::dropIfExists('lead_forms');
+
+        $admin = Admin::query()->create([
+            'username' => 'site_settings_no_leads_admin',
+            'password' => 'secret-123',
+            'email' => 'site-settings-no-leads-admin@example.com',
+            'display_name' => 'Site Settings No Leads Admin',
+            'role' => 'admin',
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->get(route('admin.site-settings.index'))
+            ->assertOk()
+            ->assertSee(__('admin.site_settings.page_title'))
+            ->assertSee(__('admin.site_settings.homepage.lead_form_none'));
     }
 
     public function test_apple_support_theme_is_listed_without_becoming_active_theme(): void

--- a/tests/Feature/SiteArticleMarkdownRenderTest.php
+++ b/tests/Feature/SiteArticleMarkdownRenderTest.php
@@ -9,6 +9,7 @@ use App\Models\SiteSetting;
 use App\Support\Site\ArticleHtmlPresenter;
 use App\Support\Site\SiteSettingsBag;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class SiteArticleMarkdownRenderTest extends TestCase
@@ -37,6 +38,16 @@ MD);
         $this->assertStringContainsString('src="/storage/uploads/images/2026/04/demo.png"', $html);
         $this->assertStringNotContainsString('333.png', $html);
         $this->assertStringContainsString('type="checkbox"', $html);
+    }
+
+    public function test_homepage_renders_before_lead_forms_table_is_migrated(): void
+    {
+        Schema::dropIfExists('lead_submissions');
+        Schema::dropIfExists('lead_forms');
+
+        $this->get(route('site.home'))
+            ->assertOk()
+            ->assertSee(__('site.home_latest'));
     }
 
     public function test_published_article_page_outputs_normalized_image_url(): void


### PR DESCRIPTION
## Summary
- Prevent Growth Center, Site Settings, and the public homepage from querying lead tables before the new migrations have run.
- Add regression coverage for the deployment window where lead tables are not created yet.
- Ran the pending lead migrations in the local Docker app container for localhost:18080.

## Test Plan
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/AdminAnalyticsPageTest.php tests/Feature/AdminSiteSettingsPageTest.php tests/Feature/SiteArticleMarkdownRenderTest.php
- php artisan test --compact
- docker exec geoflow-app php artisan migrate:status | tail -8