### PR TITLE
Polish lead form field configuration

### DIFF
--- a/app/Support/Lead/LeadFormFields.php
+++ b/app/Support/Lead/LeadFormFields.php
@@ -129,7 +129,7 @@ final class LeadFormFields
     private static function normalizeOptions(mixed $options): array
     {
         if (is_string($options)) {
-            $options = preg_split('/\R/u', $options) ?: [];
+            $options = preg_split('/\R|[|,，、]+/u', $options) ?: [];
         }
 
         if (! is_array($options)) {

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1803,6 +1803,7 @@ return [
             'checkbox' => 'Checkbox',
         ],
         'options_placeholder' => "One option per line\nExample: Consulting",
+        'options_placeholder_inline' => 'Separate with commas, e.g. Consulting, Demo',
         'defaults' => [
             'name' => 'Name',
             'phone' => 'Phone',

--- a/lang/pt_BR/admin.php
+++ b/lang/pt_BR/admin.php
@@ -4892,6 +4892,7 @@ return array_replace_recursive($base, [
         ],
         'type' => ['text' => 'Texto', 'phone' => 'Telefone', 'email' => 'Email', 'textarea' => 'Área de Texto', 'select' => 'Seleção', 'checkbox' => 'Checkbox'],
         'options_placeholder' => "Uma opção por linha\nExemplo: Consultoria",
+        'options_placeholder_inline' => 'Separe por vírgulas, ex.: Consultoria, Demo',
         'defaults' => ['name' => 'Nome', 'phone' => 'Telefone', 'email' => 'Email', 'message' => 'Mensagem', 'checkbox_option' => 'Concordo em enviar estas informações', 'select_option' => 'Opção padrão'],
         'error' => [
             'fields_required' => 'Configure pelo menos um campo válido',

--- a/lang/zh_CN/admin.php
+++ b/lang/zh_CN/admin.php
@@ -1803,6 +1803,7 @@ return [
             'checkbox' => '勾选',
         ],
         'options_placeholder' => "每行一个选项\n例如：咨询服务",
+        'options_placeholder_inline' => '用逗号分隔，例如：咨询服务，报价咨询',
         'defaults' => [
             'name' => '姓名',
             'phone' => '手机号',

--- a/resources/views/admin/lead-forms/form.blade.php
+++ b/resources/views/admin/lead-forms/form.blade.php
@@ -3,6 +3,9 @@
 @php
     $leadForm = $leadForm ?? null;
     $rows = collect($fields ?? [])->values()->all();
+    $controlClass = 'h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
+    $selectClass = 'h-10 w-full appearance-none rounded-md border border-gray-300 bg-white px-3 pr-10 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
+    $checkboxClass = 'h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500';
     while (count($rows) < 8) {
         $rows[] = ['name' => '', 'label' => '', 'type' => 'text', 'required' => false, 'options' => []];
     }
@@ -43,11 +46,14 @@
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">{{ __('admin.lead_forms.field.status') }}</label>
-                        <select name="status" class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                            @foreach (['active', 'inactive'] as $status)
-                                <option value="{{ $status }}" @selected(old('status', $leadForm?->status ?? 'active') === $status)>{{ __('admin.lead_forms.status.'.$status) }}</option>
-                            @endforeach
-                        </select>
+                        <div class="relative">
+                            <select name="status" class="{{ $selectClass }}">
+                                @foreach (['active', 'inactive'] as $status)
+                                    <option value="{{ $status }}" @selected(old('status', $leadForm?->status ?? 'active') === $status)>{{ __('admin.lead_forms.status.'.$status) }}</option>
+                                @endforeach
+                            </select>
+                            <i data-lucide="chevron-down" class="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"></i>
+                        </div>
                     </div>
                     <div>
                         <label class="mb-2 block text-sm font-medium text-gray-700">{{ __('admin.lead_forms.field.submit_button_label') }}</label>
@@ -75,28 +81,32 @@
                             <div class="grid grid-cols-1 gap-4 lg:grid-cols-12">
                                 <div class="lg:col-span-3">
                                     <label class="mb-2 block text-xs font-medium text-gray-600">{{ __('admin.lead_forms.field.label') }}</label>
-                                    <input type="text" name="fields[{{ $index }}][label]" value="{{ $field['label'] ?? '' }}" class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                    <input type="text" name="fields[{{ $index }}][label]" value="{{ $field['label'] ?? '' }}" class="{{ $controlClass }}">
                                 </div>
                                 <div class="lg:col-span-2">
                                     <label class="mb-2 block text-xs font-medium text-gray-600">{{ __('admin.lead_forms.field.field_name') }}</label>
-                                    <input type="text" name="fields[{{ $index }}][name]" value="{{ $field['name'] ?? '' }}" class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                    <input type="text" name="fields[{{ $index }}][name]" value="{{ $field['name'] ?? '' }}" class="{{ $controlClass }} font-mono">
                                 </div>
                                 <div class="lg:col-span-2">
                                     <label class="mb-2 block text-xs font-medium text-gray-600">{{ __('admin.lead_forms.field.type') }}</label>
-                                    <select name="fields[{{ $index }}][type]" class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                                        @foreach (\App\Models\LeadForm::FIELD_TYPES as $type)
-                                            <option value="{{ $type }}" @selected(($field['type'] ?? 'text') === $type)>{{ __('admin.lead_forms.type.'.$type) }}</option>
-                                        @endforeach
-                                    </select>
+                                    <div class="relative">
+                                        <select name="fields[{{ $index }}][type]" class="{{ $selectClass }}">
+                                            @foreach (\App\Models\LeadForm::FIELD_TYPES as $type)
+                                                <option value="{{ $type }}" @selected(($field['type'] ?? 'text') === $type)>{{ __('admin.lead_forms.type.'.$type) }}</option>
+                                            @endforeach
+                                        </select>
+                                        <i data-lucide="chevron-down" class="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"></i>
+                                    </div>
                                 </div>
                                 <div class="lg:col-span-4">
                                     <label class="mb-2 block text-xs font-medium text-gray-600">{{ __('admin.lead_forms.field.options') }}</label>
-                                    <textarea name="fields[{{ $index }}][options]" rows="2" class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500" placeholder="{{ __('admin.lead_forms.options_placeholder') }}">{{ implode("\n", $field['options'] ?? []) }}</textarea>
+                                    <input type="text" name="fields[{{ $index }}][options]" value="{{ implode(', ', $field['options'] ?? []) }}" class="{{ $controlClass }}" placeholder="{{ __('admin.lead_forms.options_placeholder_inline') }}">
                                 </div>
-                                <div class="flex items-end lg:col-span-1">
-                                    <label class="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
-                                        <input type="checkbox" name="fields[{{ $index }}][required]" value="1" @checked(!empty($field['required'])) class="rounded border-gray-300 text-blue-600">
-                                        {{ __('admin.lead_forms.field.required') }}
+                                <div class="lg:col-span-1">
+                                    <span class="mb-2 block select-none text-xs font-medium text-transparent" aria-hidden="true">{{ __('admin.lead_forms.field.required') }}</span>
+                                    <label class="flex h-10 items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 shadow-sm">
+                                        <input type="checkbox" name="fields[{{ $index }}][required]" value="1" @checked(!empty($field['required'])) class="{{ $checkboxClass }}">
+                                        <span class="whitespace-nowrap">{{ __('admin.lead_forms.field.required') }}</span>
                                     </label>
                                 </div>
                             </div>

--- a/tests/Feature/AdminLeadFormsTest.php
+++ b/tests/Feature/AdminLeadFormsTest.php
@@ -13,6 +13,30 @@ class AdminLeadFormsTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_create_form_selects_use_inset_custom_chevrons(): void
+    {
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.lead-forms.create'))
+            ->assertOk()
+            ->assertSee('h-10', false)
+            ->assertSee('appearance-none', false)
+            ->assertSee('pr-10', false)
+            ->assertSee('data-lucide="chevron-down"', false)
+            ->assertSee('right-3', false);
+    }
+
+    public function test_create_form_field_rows_use_single_line_options_and_centered_required_control(): void
+    {
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.lead-forms.create'))
+            ->assertOk()
+            ->assertSee('<input type="text" name="fields[0][options]"', false)
+            ->assertDontSee('<textarea name="fields[0][options]"', false)
+            ->assertSee(__('admin.lead_forms.options_placeholder_inline'), false)
+            ->assertSee('justify-center', false)
+            ->assertSee('h-4 w-4', false);
+    }
+
     public function test_admin_can_create_edit_toggle_and_delete_lead_forms(): void
     {
         $this->withoutMiddleware(ValidateCsrfToken::class);
@@ -29,7 +53,7 @@ class AdminLeadFormsTest extends TestCase
                 'success_message' => '已收到预约',
                 'fields' => [
                     ['label' => '姓名', 'name' => 'name', 'type' => 'text', 'required' => '1'],
-                    ['label' => '预算', 'name' => 'budget', 'type' => 'select', 'required' => '1', 'options' => "1万以内\n1-5万"],
+                    ['label' => '预算', 'name' => 'budget', 'type' => 'select', 'required' => '1', 'options' => "1万以内\n1-5万，5万以上|定制预算"],
                     ['label' => '公司名称', 'name' => '', 'type' => 'text', 'required' => ''],
                     ['label' => '来源页面', 'name' => 'source_url', 'type' => 'text', 'required' => ''],
                 ],
@@ -39,7 +63,7 @@ class AdminLeadFormsTest extends TestCase
         $form = LeadForm::query()->firstOrFail();
         $this->assertSame('product-demo', $form->slug);
         $this->assertSame('budget', $form->fields[1]['name']);
-        $this->assertSame(['1万以内', '1-5万'], $form->fields[1]['options']);
+        $this->assertSame(['1万以内', '1-5万', '5万以上', '定制预算'], $form->fields[1]['options']);
         $this->assertSame('field_3', $form->fields[2]['name']);
         $this->assertSame('source_url_field', $form->fields[3]['name']);
 


### PR DESCRIPTION
## Summary
- make lead form field options a single-line control aligned with other field controls
- center and size the required checkbox control
- support comma-style option splitting for single-line option entry

## Tests
- php artisan test --compact tests/Feature/SiteLeadSubmissionTest.php tests/Feature/AdminLeadFormsTest.php tests/Feature/AdminSiteSettingsPageTest.php