### PR TITLE
test: enforce release version mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,10 @@
             "@php artisan config:clear --ansi",
             "@php artisan test"
         ],
+        "version:check": [
+            "@php artisan config:clear --ansi",
+            "@php artisan test --compact tests/Unit/ReleaseVersionMappingTest.php"
+        ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/config/geoflow.php
+++ b/config/geoflow.php
@@ -15,7 +15,7 @@ $versionManifest = is_file($versionManifestPath)
     ? json_decode((string) file_get_contents($versionManifestPath), true)
     : [];
 $appVersion = is_array($versionManifest) ? trim((string) ($versionManifest['version'] ?? '')) : '';
-$appVersion = $appVersion !== '' ? $appVersion : '2.1.1';
+$appVersion = $appVersion !== '' ? $appVersion : '0.0.0-dev';
 
 return [
 

--- a/tests/Unit/ReleaseVersionMappingTest.php
+++ b/tests/Unit/ReleaseVersionMappingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class ReleaseVersionMappingTest extends TestCase
+{
+    public function test_manifest_version_is_semver_and_application_config_tracks_it(): void
+    {
+        $manifest = json_decode(
+            (string) file_get_contents(base_path('version.json')),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/D',
+            $manifest['version'],
+        );
+        $this->assertSame($manifest['version'], config('geoflow.app_version'));
+    }
+
+    public function test_config_uses_a_development_version_when_the_manifest_is_unavailable(): void
+    {
+        $configSource = (string) file_get_contents(config_path('geoflow.php'));
+
+        $this->assertStringContainsString(
+            "\$appVersion = \$appVersion !== '' ? \$appVersion : '0.0.0-dev';",
+            $configSource,
+        );
+    }
+
+    public function test_release_metadata_is_derived_from_the_manifest_tag(): void
+    {
+        $manifest = json_decode(
+            (string) file_get_contents(base_path('version.json')),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertArrayHasKey('tag', $manifest);
+
+        $version = $manifest['version'];
+        $tag = $manifest['tag'];
+        $payload = $manifest['payload'];
+
+        $this->assertSame("v{$version}", $tag);
+        $this->assertSame(
+            "https://github.com/yaojingang/GEOFlow/archive/refs/tags/{$tag}.zip",
+            $manifest['archive_url'],
+        );
+        $this->assertSame(
+            "https://github.com/yaojingang/GEOFlow/releases/tag/{$tag}",
+            $payload['release_url'],
+        );
+        $this->assertSame(
+            "https://github.com/yaojingang/GEOFlow/blob/{$tag}/docs/CHANGELOG.md",
+            $payload['changelog_url_zh'],
+        );
+        $this->assertSame(
+            "https://github.com/yaojingang/GEOFlow/blob/{$tag}/docs/CHANGELOG_en.md",
+            $payload['changelog_url_en'],
+        );
+        $this->assertSame("GEOFlow v{$version}", $payload['title_zh']);
+        $this->assertSame("GEOFlow v{$version}", $payload['title_en']);
+    }
+}

--- a/tests/Unit/SecurityReleaseMetadataTest.php
+++ b/tests/Unit/SecurityReleaseMetadataTest.php
@@ -58,13 +58,11 @@ class SecurityReleaseMetadataTest extends TestCase
         $this->assertStringNotContainsString('v2.1.1 has been released', strtolower($en));
     }
 
-    public function test_config_fallback_tracks_v211_without_environment_version_lock(): void
+    public function test_environment_examples_do_not_lock_the_application_version(): void
     {
-        $config = (string) file_get_contents(config_path('geoflow.php'));
         $envExample = (string) file_get_contents(base_path('.env.example'));
         $productionExample = (string) file_get_contents(base_path('.env.prod.example'));
 
-        $this->assertStringContainsString("\$appVersion !== '' ? \$appVersion : '2.1.1'", $config);
         $this->assertStringNotContainsString('GEOFLOW_APP_VERSION=', $envExample);
         $this->assertStringNotContainsString('GEOFLOW_APP_VERSION=', $productionExample);
     }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
   "version": "2.1.1",
+  "tag": "v2.1.1",
   "release_date": "2026-07-17",
   "release_type": "patch",
   "archive_url": "https://github.com/yaojingang/GEOFlow/archive/refs/tags/v2.1.1.zip",


### PR DESCRIPTION
## Summary

- add a single release-version mapping check for Composer, package metadata, runtime config, and the published tag
- add `composer version:check` for local and CI verification
- use an explicit development fallback when no release version is configured

## Verification

- `composer validate --strict --no-check-publish`
- `php artisan test --compact tests/Unit/ReleaseVersionMappingTest.php tests/Unit/SecurityReleaseMetadataTest.php` (6 passed, 45 assertions)