### PR TITLE
fix: harden AI usage quotas and visibility analytics

### DIFF
--- a/app/Http/Controllers/Admin/AiModelController.php
+++ b/app/Http/Controllers/Admin/AiModelController.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\AiModel;
 use App\Models\Article;
 use App\Models\SiteSetting;
+use App\Services\GeoFlow\AiUsageQuotaService;
+use App\Services\GeoFlow\AiUsageReservation;
 use App\Services\Outbound\SafeOutboundHttpClient;
 use App\Support\AdminWeb;
 use App\Support\GeoFlow\ApiKeyCrypto;
@@ -37,6 +39,7 @@ class AiModelController extends Controller
         private readonly ApiKeyCrypto $apiKeyCrypto,
         private readonly SafeOutboundHttpClient $safeHttp,
         private readonly Factory $http,
+        private readonly AiUsageQuotaService $usageQuota,
     ) {}
 
     /**
@@ -186,12 +189,13 @@ class AiModelController extends Controller
     /**
      * 测试单个 AI 模型的 API 连通性。
      *
-     * 只发起最小化请求，不增加模型调用统计，也不返回敏感密钥。
+     * 只发起最小化请求，并纳入统一每日额度与调用统计，不返回敏感密钥。
      */
     public function testConnection(int $modelId): JsonResponse
     {
         $model = AiModel::query()->whereKey($modelId)->firstOrFail();
         $startedAt = microtime(true);
+        $reservation = null;
 
         try {
             $modelType = $this->normalizeModelType((string) ($model->model_type ?? 'chat'));
@@ -208,6 +212,17 @@ class AiModelController extends Controller
             }
             if ($modelName === '') {
                 return $this->modelTestResponse(false, __('admin.ai_models.test_error_model_missing'), $startedAt, $modelType, $endpoint);
+            }
+
+            $reservation = $this->usageQuota->reserveModel($model);
+            if ($reservation === null) {
+                return $this->modelTestResponse(
+                    false,
+                    __('admin.ai_models.test_error_daily_limit'),
+                    $startedAt,
+                    $modelType,
+                    $endpoint,
+                );
             }
 
             $request = $this->http->acceptJson()
@@ -228,6 +243,8 @@ class AiModelController extends Controller
 
             $json = $response->json();
             if (! $response->successful()) {
+                $this->usageQuota->releaseModel($reservation);
+
                 return $this->modelTestResponse(
                     false,
                     __('admin.ai_models.test_failed_with_status', [
@@ -242,6 +259,8 @@ class AiModelController extends Controller
             }
 
             if (! $this->isValidTestResponse($json, $modelType, $isGemini)) {
+                $this->usageQuota->releaseModel($reservation);
+
                 return $this->modelTestResponse(
                     false,
                     __('admin.ai_models.test_invalid_response', [
@@ -254,6 +273,12 @@ class AiModelController extends Controller
                 );
             }
 
+            try {
+                $this->usageQuota->recordModelSuccess($reservation);
+            } catch (Throwable $exception) {
+                report($exception);
+            }
+
             return $this->modelTestResponse(
                 true,
                 __('admin.ai_models.test_success', ['type' => $modelType === 'embedding' ? 'Embedding' : 'Chat']),
@@ -263,6 +288,10 @@ class AiModelController extends Controller
                 $response->status()
             );
         } catch (Throwable $exception) {
+            if ($reservation instanceof AiUsageReservation) {
+                $this->usageQuota->releaseModel($reservation);
+            }
+
             return $this->modelTestResponse(
                 false,
                 __('admin.ai_models.test_exception', ['message' => $this->redactedRemoteDetail()]),
@@ -362,6 +391,7 @@ class AiModelController extends Controller
             'failover_priority',
             'daily_limit',
             'used_today',
+            'usage_date',
             'total_used',
             'status',
             'created_at',
@@ -397,7 +427,7 @@ class AiModelController extends Controller
                 'api_url' => (string) ($model->api_url ?? ''),
                 'failover_priority' => (int) ($model->failover_priority ?? 100),
                 'daily_limit' => (int) ($model->daily_limit ?? 0),
-                'used_today' => (int) ($model->used_today ?? 0),
+                'used_today' => $model->currentUsage(),
                 'total_used' => (int) ($model->total_used ?? 0),
                 'status' => (string) ($model->status ?? 'active'),
                 'max_tokens' => $supportsMaxTokens && $model->max_tokens !== null ? (int) $model->max_tokens : null,

--- a/app/Http/Controllers/Admin/AiSourceProviderController.php
+++ b/app/Http/Controllers/Admin/AiSourceProviderController.php
@@ -10,6 +10,7 @@ use App\Models\SiteSetting;
 use App\Services\GeoFlow\AiUsageQuotaService;
 use App\Services\GeoFlow\AiVisibility\AiProviderEndpointPolicy;
 use App\Services\GeoFlow\AiVisibility\AiStructuredOutputHealthCheck;
+use App\Services\GeoFlow\AiVisibility\AiVisibilityConfigurationResolver;
 use App\Services\GeoFlow\AiVisibility\AiVisibilityResult;
 use App\Services\GeoFlow\AiVisibility\DoubaoSearchCustomClient;
 use App\Support\AdminWeb;
@@ -24,9 +25,9 @@ use Throwable;
 
 class AiSourceProviderController extends Controller
 {
-    private const ARK_MODEL_SETTING_KEY = 'ai_visibility_ark_model_id';
+    private const ARK_MODEL_SETTING_KEY = AiVisibilityConfigurationResolver::ARK_MODEL_SETTING_KEY;
 
-    private const DEEPSEEK_MODEL_SETTING_KEY = 'ai_visibility_deepseek_analysis_model_id';
+    private const DEEPSEEK_MODEL_SETTING_KEY = AiVisibilityConfigurationResolver::DEEPSEEK_MODEL_SETTING_KEY;
 
     public function __construct(
         private readonly ApiKeyCrypto $apiKeyCrypto,
@@ -34,6 +35,7 @@ class AiSourceProviderController extends Controller
         private readonly AiStructuredOutputHealthCheck $structuredOutputHealthCheck,
         private readonly AiProviderEndpointPolicy $endpointPolicy,
         private readonly AiUsageQuotaService $usageQuota,
+        private readonly AiVisibilityConfigurationResolver $configuration,
     ) {}
 
     public function index(): View
@@ -594,43 +596,22 @@ class AiSourceProviderController extends Controller
 
     private function isCallableArkModelId(int $modelId): bool
     {
-        $model = AiModel::query()->whereKey($modelId)->first();
-
-        return $model instanceof AiModel && $this->isCallableArkModel($model);
+        return $this->configuration->isCallableModelId($modelId, 'ark');
     }
 
     private function isCallableDeepSeekModelId(int $modelId): bool
     {
-        $model = AiModel::query()->whereKey($modelId)->first();
-
-        return $model instanceof AiModel && $this->isCallableDeepSeekModel($model);
+        return $this->configuration->isCallableModelId($modelId, 'deepseek');
     }
 
     private function isCallableArkModel(AiModel $model): bool
     {
-        return $this->isActiveChatModel($model)
-            && $this->hasStoredApiKey($model)
-            && $this->endpointPolicy->acceptsModelApi('ark', (string) ($model->api_url ?? ''));
+        return $this->configuration->isCallableModel($model, 'ark');
     }
 
     private function isCallableDeepSeekModel(AiModel $model): bool
     {
-        return $this->isActiveChatModel($model)
-            && $this->hasStoredApiKey($model)
-            && $this->endpointPolicy->acceptsModelApi('deepseek', (string) ($model->api_url ?? ''));
-    }
-
-    private function hasStoredApiKey(AiModel $model): bool
-    {
-        return trim((string) ($model->getRawOriginal('api_key') ?? '')) !== '';
-    }
-
-    private function isActiveChatModel(AiModel $model): bool
-    {
-        $modelType = trim((string) ($model->model_type ?? ''));
-
-        return (string) ($model->status ?? 'inactive') === 'active'
-            && ($modelType === '' || $modelType === 'chat');
+        return $this->configuration->isCallableModel($model, 'deepseek');
     }
 
     private function modelProviderHint(AiModel $model): string

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -288,15 +288,22 @@ class DashboardController extends Controller
             $out['embedding_models'] = (int) (clone $activeModels)
                 ->where('model_type', 'embedding')
                 ->count();
-            $out['used_today'] = (int) AiModel::query()->sum('used_today');
+            $out['used_today'] = (int) AiModel::query()
+                ->forCurrentUsageDay()
+                ->sum('used_today');
             $out['total_used'] = (int) AiModel::query()->sum('total_used');
             $out['active_models'] = AiModel::query()
                 ->where('status', 'active')
                 ->orderBy('failover_priority')
                 ->orderBy('id')
-                ->select('id', 'name', 'model_id', 'model_type', 'used_today', 'daily_limit')
+                ->select('id', 'name', 'model_id', 'model_type', 'used_today', 'usage_date', 'daily_limit')
                 ->limit(5)
                 ->get()
+                ->map(function (AiModel $model): AiModel {
+                    $model->setAttribute('used_today', $model->currentUsage());
+
+                    return $model;
+                })
                 ->all();
         } catch (\Throwable) {
             // ignore

--- a/app/Http/Controllers/Admin/LegacyController.php
+++ b/app/Http/Controllers/Admin/LegacyController.php
@@ -204,12 +204,16 @@ class LegacyController extends Controller
             'model_count' => AiModel::query()->where('status', 'active')->count(),
             'prompt_count' => Prompt::query()->count(),
             'total_usage' => (int) (AiModel::query()->sum('total_used') ?? 0),
-            'today_usage' => (int) (AiModel::query()->sum('used_today') ?? 0),
+            'today_usage' => (int) (AiModel::query()
+                ->forCurrentUsageDay()
+                ->sum('used_today') ?? 0),
             'search_provider_count' => Schema::hasTable('ai_source_providers')
                 ? AiSourceProvider::query()->where('status', 'active')->count()
                 : 0,
             'search_provider_today_usage' => Schema::hasTable('ai_source_providers')
-                ? (int) (AiSourceProvider::query()->sum('used_today') ?? 0)
+                ? (int) (AiSourceProvider::query()
+                    ->whereDate('usage_date', now()->toDateString())
+                    ->sum('used_today') ?? 0)
                 : 0,
             'visibility_failed_runs' => Schema::hasTable('ai_visibility_runs')
                 ? AiVisibilityRun::query()->where('status', AiVisibilityRun::STATUS_FAILED)->count()

--- a/app/Models/AiModel.php
+++ b/app/Models/AiModel.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -54,5 +55,17 @@ class AiModel extends Model
     public function visibilityRuns(): HasMany
     {
         return $this->hasMany(AiVisibilityRun::class, 'ai_model_id');
+    }
+
+    public function currentUsage(): int
+    {
+        return $this->usage_date?->toDateString() === now()->toDateString()
+            ? max(0, (int) ($this->used_today ?? 0))
+            : 0;
+    }
+
+    public function scopeForCurrentUsageDay(Builder $query): Builder
+    {
+        return $query->whereDate('usage_date', now()->toDateString());
     }
 }

--- a/app/Services/Admin/Analytics/AiVisibilityAnalyticsService.php
+++ b/app/Services/Admin/Analytics/AiVisibilityAnalyticsService.php
@@ -2,14 +2,13 @@
 
 namespace App\Services\Admin\Analytics;
 
-use App\Models\AiModel;
-use App\Models\AiSourceProvider;
 use App\Models\AiVisibilityRun;
 use App\Models\AiVisibilitySource;
-use App\Models\SiteSetting;
-use App\Services\GeoFlow\AiVisibility\AiProviderEndpointPolicy;
+use App\Services\GeoFlow\AiVisibility\AiVisibilityConfigurationResolver;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -17,12 +16,8 @@ class AiVisibilityAnalyticsService
 {
     private const DAILY_SAMPLE_TARGET = 5;
 
-    private const ARK_MODEL_SETTING_KEY = 'ai_visibility_ark_model_id';
-
-    private const DEEPSEEK_MODEL_SETTING_KEY = 'ai_visibility_deepseek_analysis_model_id';
-
     public function __construct(
-        private readonly AiProviderEndpointPolicy $endpointPolicy,
+        private readonly AiVisibilityConfigurationResolver $configuration,
     ) {}
 
     /**
@@ -39,32 +34,22 @@ class AiVisibilityAnalyticsService
 
         $start = now()->copy()->startOfDay()->subDays($days - 1);
         $end = now()->copy()->endOfDay();
-        $runs = AiVisibilityRun::query()
-            ->with(['sources' => fn ($query) => $query->orderByRaw('COALESCE(rank, 999999) asc')->orderBy('id')])
-            ->where(function ($query) use ($start, $end): void {
-                $query
-                    ->whereBetween('completed_at', [$start, $end])
-                    ->orWhere(function ($query) use ($start, $end): void {
-                        $query
-                            ->whereNull('completed_at')
-                            ->whereBetween('created_at', [$start, $end]);
-                    });
-            })
-            ->orderBy('created_at')
-            ->get();
-
-        if ($runs->isEmpty()) {
+        $periodRuns = $this->periodRunsQuery($start, $end);
+        $runCount = (int) (clone $periodRuns)->count();
+        if ($runCount === 0) {
             return $this->emptyOverview(true, $days, $configuration);
         }
 
-        $completedRuns = $runs
+        $completedRunCount = (int) (clone $periodRuns)
             ->where('status', AiVisibilityRun::STATUS_COMPLETED)
-            ->values();
-
-        $sampledRuns = $completedRuns
-            ->groupBy(fn (AiVisibilityRun $run): string => $this->runDate($run).'|'.Str::lower(trim((string) $run->keyword)))
-            ->flatMap(fn (Collection $rows): Collection => $rows->sortBy('created_at')->take(self::DAILY_SAMPLE_TARGET))
-            ->values();
+            ->count();
+        $sampledRunIds = $this->sampledRunIds($start, $end);
+        $sampledRuns = AiVisibilityRun::query()
+            ->with(['sources' => fn ($query) => $query->orderByRaw('COALESCE(rank, 999999) asc')->orderBy('id')])
+            ->whereIn('id', $sampledRunIds)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
 
         $brandAliases = $this->brandAliases();
         $ownedHosts = $this->ownedHosts();
@@ -75,14 +60,16 @@ class AiVisibilityAnalyticsService
         $dailyKeywordMetrics = $this->dailyKeywordMetrics($analyzedRuns);
         $kpis = $this->kpis($dailyKeywordMetrics);
         $sourcePreferences = $this->sourcePreferences($analyzedRuns);
-        $todayRuns = $runs->filter(fn (AiVisibilityRun $run): bool => $this->runDate($run) === now()->toDateString());
-        $todayCompletedRuns = $todayRuns->where('status', AiVisibilityRun::STATUS_COMPLETED);
-        $todayKeywordCount = $todayRuns
-            ->pluck('keyword')
-            ->map(fn (mixed $keyword): string => Str::lower(trim((string) $keyword)))
-            ->filter()
-            ->unique()
+        $todayRuns = $this->periodRunsQuery(now()->copy()->startOfDay(), now()->copy()->endOfDay());
+        $todayRunCount = (int) (clone $todayRuns)->count();
+        $todayCompletedRunCount = (int) (clone $todayRuns)
+            ->where('status', AiVisibilityRun::STATUS_COMPLETED)
             ->count();
+        $todayKeywordCount = (int) ((clone $todayRuns)
+            ->whereRaw("TRIM(COALESCE(keyword, '')) <> ''")
+            ->selectRaw('COUNT(DISTINCT LOWER(TRIM(keyword))) as aggregate')
+            ->toBase()
+            ->value('aggregate') ?? 0);
 
         return [
             'ready' => true,
@@ -101,12 +88,12 @@ class AiVisibilityAnalyticsService
             ],
             'kpis' => $kpis,
             'polling' => [
-                'runs' => $runs->count(),
-                'completed_runs' => $completedRuns->count(),
+                'runs' => $runCount,
+                'completed_runs' => $completedRunCount,
                 'sampled_runs' => $sampledRuns->count(),
-                'success_rate' => $this->percent($completedRuns->count(), $runs->count()),
-                'today_runs' => $todayRuns->count(),
-                'today_completed_runs' => $todayCompletedRuns->count(),
+                'success_rate' => $this->percent($completedRunCount, $runCount),
+                'today_runs' => $todayRunCount,
+                'today_completed_runs' => $todayCompletedRunCount,
                 'today_keyword_count' => $todayKeywordCount,
                 'today_target_samples' => $todayKeywordCount * self::DAILY_SAMPLE_TARGET,
             ],
@@ -117,6 +104,43 @@ class AiVisibilityAnalyticsService
             'attention_sources' => $this->attentionSources($sourcePreferences),
             'latest_runs' => $this->latestRuns($analyzedRuns),
         ];
+    }
+
+    private function periodRunsQuery(Carbon $start, Carbon $end): Builder
+    {
+        return AiVisibilityRun::query()
+            ->where(function (Builder $query) use ($start, $end): void {
+                $query
+                    ->whereBetween('completed_at', [$start, $end])
+                    ->orWhere(function (Builder $query) use ($start, $end): void {
+                        $query
+                            ->whereNull('completed_at')
+                            ->whereBetween('created_at', [$start, $end]);
+                    });
+            });
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function sampledRunIds(Carbon $start, Carbon $end): array
+    {
+        $rankedRuns = $this->periodRunsQuery($start, $end)
+            ->where('status', AiVisibilityRun::STATUS_COMPLETED)
+            ->select('id')
+            ->selectRaw(
+                'ROW_NUMBER() OVER (
+                    PARTITION BY DATE(COALESCE(completed_at, created_at)), LOWER(TRIM(keyword))
+                    ORDER BY created_at, id
+                ) AS sample_rank'
+            );
+
+        return DB::query()
+            ->fromSub($rankedRuns, 'ranked_ai_visibility_runs')
+            ->where('sample_rank', '<=', self::DAILY_SAMPLE_TARGET)
+            ->pluck('id')
+            ->map(static fn (mixed $id): int => (int) $id)
+            ->all();
     }
 
     /**
@@ -863,81 +887,7 @@ class AiVisibilityAnalyticsService
      */
     private function configurationStatus(): array
     {
-        $doubaoSearchConfigured = $this->hasActiveDoubaoSearchProvider();
-        $arkConfigured = $this->hasConfiguredModel(self::ARK_MODEL_SETTING_KEY, 'ark');
-        $deepSeekConfigured = $this->hasConfiguredModel(self::DEEPSEEK_MODEL_SETTING_KEY, 'deepseek');
-
-        return [
-            'configured' => $doubaoSearchConfigured || $arkConfigured || $deepSeekConfigured,
-            'doubao_search_configured' => $doubaoSearchConfigured,
-            'ark_configured' => $arkConfigured,
-            'deepseek_configured' => $deepSeekConfigured,
-        ];
-    }
-
-    private function hasActiveDoubaoSearchProvider(): bool
-    {
-        if (! Schema::hasTable('ai_source_providers')) {
-            return false;
-        }
-
-        $query = AiSourceProvider::query()
-            ->where('provider_key', AiSourceProvider::PROVIDER_DOUBAO_SEARCH_CUSTOM)
-            ->where('status', 'active')
-            ->whereNotNull('api_key')
-            ->where('api_key', '<>', '');
-
-        if (trim((string) config('geoflow.ai_visibility.doubao_search_endpoint', '')) === '') {
-            $query->whereRaw("TRIM(COALESCE(endpoint_url, '')) <> ''");
-        }
-
-        return $query->exists();
-    }
-
-    private function hasConfiguredModel(string $settingKey, string $bindingType): bool
-    {
-        if (! Schema::hasTable('site_settings') || ! Schema::hasTable('ai_models')) {
-            return false;
-        }
-
-        $modelId = (int) (SiteSetting::query()
-            ->where('setting_key', $settingKey)
-            ->value('setting_value') ?? 0);
-
-        if ($modelId <= 0) {
-            return false;
-        }
-
-        $model = AiModel::query()->whereKey($modelId)->first();
-        if (! $model instanceof AiModel) {
-            return false;
-        }
-
-        return $bindingType === 'ark'
-            ? $this->isCallableArkModel($model)
-            : $this->isCallableDeepSeekModel($model);
-    }
-
-    private function isCallableArkModel(AiModel $model): bool
-    {
-        return $this->isActiveChatModel($model)
-            && $this->endpointPolicy->acceptsModelApi('ark', (string) ($model->api_url ?? ''))
-            && trim((string) ($model->getRawOriginal('api_key') ?? '')) !== '';
-    }
-
-    private function isCallableDeepSeekModel(AiModel $model): bool
-    {
-        return $this->isActiveChatModel($model)
-            && $this->endpointPolicy->acceptsModelApi('deepseek', (string) ($model->api_url ?? ''))
-            && trim((string) ($model->getRawOriginal('api_key') ?? '')) !== '';
-    }
-
-    private function isActiveChatModel(AiModel $model): bool
-    {
-        $modelType = trim((string) ($model->model_type ?? ''));
-
-        return (string) ($model->status ?? 'inactive') === 'active'
-            && ($modelType === '' || $modelType === 'chat');
+        return $this->configuration->status();
     }
 
     private function runDate(AiVisibilityRun $run): string

--- a/app/Services/Admin/Analytics/AnalyticsOverviewService.php
+++ b/app/Services/Admin/Analytics/AnalyticsOverviewService.php
@@ -80,7 +80,9 @@ class AnalyticsOverviewService
             'published' => (int) $published->count(),
             'running_tasks' => (int) (clone $taskRuns)->where('status', 'running')->count(),
             'failed_tasks' => (int) (clone $taskRuns)->where('status', 'failed')->count(),
-            'ai_calls' => (int) AiModel::query()->sum('used_today'),
+            'ai_calls' => (int) AiModel::query()
+                ->forCurrentUsageDay()
+                ->sum('used_today'),
             'total_views' => $this->filteredViewCount($filter),
         ];
 
@@ -236,15 +238,22 @@ class AnalyticsOverviewService
     public function aiUsageSummary(AnalyticsFilter $filter): array
     {
         return [
-            'used_today' => (int) AiModel::query()->sum('used_today'),
+            'used_today' => (int) AiModel::query()
+                ->forCurrentUsageDay()
+                ->sum('used_today'),
             'total_used' => (int) AiModel::query()->sum('total_used'),
             'active_models' => (int) AiModel::query()->where('status', 'active')->count(),
             'model_rows' => AiModel::query()
                 ->where('status', 'active')
-                ->orderByDesc('used_today')
-                ->select('id', 'name', 'model_id', 'model_type', 'used_today', 'total_used')
+                ->orderByRaw('CASE WHEN usage_date = ? THEN used_today ELSE 0 END DESC', [now()->toDateString()])
+                ->select('id', 'name', 'model_id', 'model_type', 'used_today', 'usage_date', 'total_used')
                 ->limit(5)
                 ->get()
+                ->map(function (AiModel $model): AiModel {
+                    $model->setAttribute('used_today', $model->currentUsage());
+
+                    return $model;
+                })
                 ->all(),
         ];
     }
@@ -396,15 +405,22 @@ class AnalyticsOverviewService
             'embedding_models' => (int) (clone $activeModels)
                 ->where('model_type', 'embedding')
                 ->count(),
-            'used_today' => (int) AiModel::query()->sum('used_today'),
+            'used_today' => (int) AiModel::query()
+                ->forCurrentUsageDay()
+                ->sum('used_today'),
             'total_used' => (int) AiModel::query()->sum('total_used'),
             'active_models' => AiModel::query()
                 ->where('status', 'active')
                 ->orderBy('failover_priority')
                 ->orderBy('id')
-                ->select('id', 'name', 'model_id', 'model_type', 'used_today', 'daily_limit')
+                ->select('id', 'name', 'model_id', 'model_type', 'used_today', 'usage_date', 'daily_limit')
                 ->limit(5)
                 ->get()
+                ->map(function (AiModel $model): AiModel {
+                    $model->setAttribute('used_today', $model->currentUsage());
+
+                    return $model;
+                })
                 ->all(),
         ];
     }

--- a/app/Services/GeoFlow/AiUsageQuotaService.php
+++ b/app/Services/GeoFlow/AiUsageQuotaService.php
@@ -4,7 +4,9 @@ namespace App\Services\GeoFlow;
 
 use App\Models\AiModel;
 use App\Models\AiSourceProvider;
+use Closure;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 final class AiUsageQuotaService
 {
@@ -25,15 +27,16 @@ final class AiUsageQuotaService
         if ($reservation->resourceType !== 'model') {
             throw new \InvalidArgumentException('Expected an AI model usage reservation.');
         }
-
-        AiModel::query()
-            ->whereKey($reservation->resourceId)
-            ->whereDate('usage_date', $reservation->usageDate)
-            ->where('used_today', '>', 0)
-            ->update([
-                'used_today' => DB::raw('COALESCE(used_today, 0) - 1'),
-                'updated_at' => now(),
-            ]);
+        $this->finalizeReservation($reservation, static function () use ($reservation): void {
+            AiModel::query()
+                ->whereKey($reservation->resourceId)
+                ->whereDate('usage_date', $reservation->usageDate)
+                ->where('used_today', '>', 0)
+                ->update([
+                    'used_today' => DB::raw('COALESCE(used_today, 0) - 1'),
+                    'updated_at' => now(),
+                ]);
+        });
     }
 
     public function recordModelSuccess(AiUsageReservation $reservation): void
@@ -41,11 +44,12 @@ final class AiUsageQuotaService
         if ($reservation->resourceType !== 'model') {
             throw new \InvalidArgumentException('Expected an AI model usage reservation.');
         }
-
-        AiModel::query()->whereKey($reservation->resourceId)->update([
-            'total_used' => DB::raw('COALESCE(total_used, 0) + 1'),
-            'updated_at' => now(),
-        ]);
+        $this->finalizeReservation($reservation, static function () use ($reservation): void {
+            AiModel::query()->whereKey($reservation->resourceId)->update([
+                'total_used' => DB::raw('COALESCE(total_used, 0) + 1'),
+                'updated_at' => now(),
+            ]);
+        });
     }
 
     public function reserveProvider(AiSourceProvider $provider): ?AiUsageReservation
@@ -65,15 +69,16 @@ final class AiUsageQuotaService
         if ($reservation->resourceType !== 'provider') {
             throw new \InvalidArgumentException('Expected an AI source provider usage reservation.');
         }
-
-        AiSourceProvider::query()
-            ->whereKey($reservation->resourceId)
-            ->whereDate('usage_date', $reservation->usageDate)
-            ->where('used_today', '>', 0)
-            ->update([
-                'used_today' => DB::raw('COALESCE(used_today, 0) - 1'),
-                'updated_at' => now(),
-            ]);
+        $this->finalizeReservation($reservation, static function () use ($reservation): void {
+            AiSourceProvider::query()
+                ->whereKey($reservation->resourceId)
+                ->whereDate('usage_date', $reservation->usageDate)
+                ->where('used_today', '>', 0)
+                ->update([
+                    'used_today' => DB::raw('COALESCE(used_today, 0) - 1'),
+                    'updated_at' => now(),
+                ]);
+        });
     }
 
     public function recordProviderSuccess(AiUsageReservation $reservation): void
@@ -81,11 +86,12 @@ final class AiUsageQuotaService
         if ($reservation->resourceType !== 'provider') {
             throw new \InvalidArgumentException('Expected an AI source provider usage reservation.');
         }
-
-        AiSourceProvider::query()->whereKey($reservation->resourceId)->update([
-            'total_used' => DB::raw('COALESCE(total_used, 0) + 1'),
-            'updated_at' => now(),
-        ]);
+        $this->finalizeReservation($reservation, static function () use ($reservation): void {
+            AiSourceProvider::query()->whereKey($reservation->resourceId)->update([
+                'total_used' => DB::raw('COALESCE(total_used, 0) + 1'),
+                'updated_at' => now(),
+            ]);
+        });
     }
 
     private function reserveLockedModel(AiModel $model): ?AiUsageReservation
@@ -129,5 +135,34 @@ final class AiUsageQuotaService
             : trim((string) $storedUsageDate);
 
         return $date === $usageDate ? max(0, $usedToday) : 0;
+    }
+
+    private function finalizeReservation(AiUsageReservation $reservation, Closure $operation): void
+    {
+        if (! $reservation->claimFinalization()) {
+            return;
+        }
+
+        try {
+            $operation();
+        } catch (Throwable $exception) {
+            $reservation->cancelFinalization();
+
+            throw $exception;
+        }
+
+        $connection = DB::connection();
+        if ($connection->transactionLevel() === 0) {
+            $reservation->completeFinalization();
+
+            return;
+        }
+
+        $connection->afterCommit(
+            static fn () => $reservation->completeFinalization()
+        );
+        $connection->afterRollBack(
+            static fn () => $reservation->cancelFinalization()
+        );
     }
 }

--- a/app/Services/GeoFlow/AiUsageReservation.php
+++ b/app/Services/GeoFlow/AiUsageReservation.php
@@ -2,11 +2,39 @@
 
 namespace App\Services\GeoFlow;
 
-final readonly class AiUsageReservation
+final class AiUsageReservation
 {
     public function __construct(
-        public string $resourceType,
-        public int $resourceId,
-        public string $usageDate,
+        public readonly string $resourceType,
+        public readonly int $resourceId,
+        public readonly string $usageDate,
     ) {}
+
+    private bool $finalizing = false;
+
+    private bool $finalized = false;
+
+    public function claimFinalization(): bool
+    {
+        if ($this->finalizing || $this->finalized) {
+            return false;
+        }
+
+        $this->finalizing = true;
+
+        return true;
+    }
+
+    public function completeFinalization(): void
+    {
+        $this->finalizing = false;
+        $this->finalized = true;
+    }
+
+    public function cancelFinalization(): void
+    {
+        if (! $this->finalized) {
+            $this->finalizing = false;
+        }
+    }
 }

--- a/app/Services/GeoFlow/AiVisibility/AiVisibilityCollectionService.php
+++ b/app/Services/GeoFlow/AiVisibility/AiVisibilityCollectionService.php
@@ -5,18 +5,13 @@ namespace App\Services\GeoFlow\AiVisibility;
 use App\Models\AiModel;
 use App\Models\AiSourceProvider;
 use App\Models\AiVisibilityRun;
-use App\Models\SiteSetting;
 use RuntimeException;
 
 final class AiVisibilityCollectionService
 {
-    private const ARK_MODEL_SETTING_KEY = 'ai_visibility_ark_model_id';
-
-    private const DEEPSEEK_MODEL_SETTING_KEY = 'ai_visibility_deepseek_analysis_model_id';
-
     public function __construct(
         private readonly AiVisibilityService $visibility,
-        private readonly AiProviderEndpointPolicy $endpointPolicy,
+        private readonly AiVisibilityConfigurationResolver $configuration,
     ) {}
 
     /**
@@ -29,8 +24,8 @@ final class AiVisibilityCollectionService
             throw new RuntimeException('AI 可见性关键词为空');
         }
 
-        $provider = $this->searchProvider();
-        $deepSeek = $this->configuredModel(self::DEEPSEEK_MODEL_SETTING_KEY, 'deepseek');
+        $provider = $this->configuration->searchProvider();
+        $deepSeek = $this->configuration->deepSeekModel();
         if ($provider instanceof AiSourceProvider && $deepSeek instanceof AiModel) {
             return $this->visibility->runDoubaoSearchThenDeepSeekAnalysis(
                 $provider,
@@ -39,7 +34,7 @@ final class AiVisibilityCollectionService
             );
         }
 
-        $ark = $this->configuredModel(self::ARK_MODEL_SETTING_KEY, 'ark');
+        $ark = $this->configuration->arkModel();
         if ($ark instanceof AiModel) {
             return [
                 'ark_run' => $this->visibility->runDoubaoArkResponses($ark, $keyword),
@@ -63,44 +58,5 @@ final class AiVisibilityCollectionService
         }
 
         throw new RuntimeException('没有可用的 AI 可见性模型或搜索源');
-    }
-
-    private function searchProvider(): ?AiSourceProvider
-    {
-        $providers = AiSourceProvider::query()
-            ->where('provider_key', AiSourceProvider::PROVIDER_DOUBAO_SEARCH_CUSTOM)
-            ->where('status', 'active')
-            ->orderBy('id')
-            ->get();
-
-        return $providers->first(function (AiSourceProvider $provider): bool {
-            return $this->endpointPolicy->acceptsSearchApi((string) $provider->endpoint_url)
-                && trim((string) ($provider->getRawOriginal('api_key') ?? '')) !== '';
-        });
-    }
-
-    private function configuredModel(string $settingKey, string $bindingType): ?AiModel
-    {
-        $modelId = (int) (SiteSetting::query()
-            ->where('setting_key', $settingKey)
-            ->value('setting_value') ?? 0);
-        if ($modelId <= 0) {
-            return null;
-        }
-
-        $model = AiModel::query()->whereKey($modelId)->first();
-        if (! $model instanceof AiModel) {
-            return null;
-        }
-
-        $modelType = trim((string) ($model->model_type ?? ''));
-        if ((string) ($model->status ?? 'inactive') !== 'active'
-            || ($modelType !== '' && $modelType !== 'chat')
-            || trim((string) ($model->getRawOriginal('api_key') ?? '')) === ''
-            || ! $this->endpointPolicy->acceptsModelApi($bindingType, (string) ($model->api_url ?? ''))) {
-            return null;
-        }
-
-        return $model;
     }
 }

--- a/app/Services/GeoFlow/AiVisibility/AiVisibilityConfigurationResolver.php
+++ b/app/Services/GeoFlow/AiVisibility/AiVisibilityConfigurationResolver.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services\GeoFlow\AiVisibility;
+
+use App\Models\AiModel;
+use App\Models\AiSourceProvider;
+use App\Models\SiteSetting;
+use Illuminate\Support\Facades\Schema;
+
+final class AiVisibilityConfigurationResolver
+{
+    public const ARK_MODEL_SETTING_KEY = 'ai_visibility_ark_model_id';
+
+    public const DEEPSEEK_MODEL_SETTING_KEY = 'ai_visibility_deepseek_analysis_model_id';
+
+    public function __construct(
+        private readonly AiProviderEndpointPolicy $endpointPolicy,
+    ) {}
+
+    public function searchProvider(): ?AiSourceProvider
+    {
+        if (! Schema::hasTable('ai_source_providers')) {
+            return null;
+        }
+
+        return AiSourceProvider::query()
+            ->where('provider_key', AiSourceProvider::PROVIDER_DOUBAO_SEARCH_CUSTOM)
+            ->where('status', 'active')
+            ->orderBy('id')
+            ->get()
+            ->first(fn (AiSourceProvider $provider): bool => $this->endpointPolicy
+                ->acceptsSearchApi((string) ($provider->endpoint_url ?? ''))
+                && $this->hasStoredApiKey($provider));
+    }
+
+    public function arkModel(): ?AiModel
+    {
+        return $this->configuredModel(self::ARK_MODEL_SETTING_KEY, 'ark');
+    }
+
+    public function deepSeekModel(): ?AiModel
+    {
+        return $this->configuredModel(self::DEEPSEEK_MODEL_SETTING_KEY, 'deepseek');
+    }
+
+    public function isCallableModelId(int $modelId, string $bindingType): bool
+    {
+        $model = AiModel::query()->whereKey($modelId)->first();
+
+        return $model instanceof AiModel && $this->isCallableModel($model, $bindingType);
+    }
+
+    public function isCallableModel(AiModel $model, string $bindingType): bool
+    {
+        $modelType = trim((string) ($model->model_type ?? ''));
+
+        return in_array($bindingType, ['ark', 'deepseek'], true)
+            && (string) ($model->status ?? 'inactive') === 'active'
+            && ($modelType === '' || $modelType === 'chat')
+            && $this->hasStoredApiKey($model)
+            && $this->endpointPolicy->acceptsModelApi(
+                $bindingType,
+                (string) ($model->api_url ?? ''),
+            );
+    }
+
+    /**
+     * @return array{configured: bool, doubao_search_configured: bool, ark_configured: bool, deepseek_configured: bool}
+     */
+    public function status(): array
+    {
+        $doubaoSearchConfigured = $this->searchProvider() instanceof AiSourceProvider;
+        $arkConfigured = $this->arkModel() instanceof AiModel;
+        $deepSeekConfigured = $this->deepSeekModel() instanceof AiModel;
+
+        return [
+            'configured' => $doubaoSearchConfigured || $arkConfigured || $deepSeekConfigured,
+            'doubao_search_configured' => $doubaoSearchConfigured,
+            'ark_configured' => $arkConfigured,
+            'deepseek_configured' => $deepSeekConfigured,
+        ];
+    }
+
+    private function configuredModel(string $settingKey, string $bindingType): ?AiModel
+    {
+        if (! Schema::hasTable('site_settings') || ! Schema::hasTable('ai_models')) {
+            return null;
+        }
+
+        $modelId = (int) (SiteSetting::query()
+            ->where('setting_key', $settingKey)
+            ->value('setting_value') ?? 0);
+        if ($modelId <= 0) {
+            return null;
+        }
+
+        $model = AiModel::query()->whereKey($modelId)->first();
+
+        return $model instanceof AiModel && $this->isCallableModel($model, $bindingType)
+            ? $model
+            : null;
+    }
+
+    private function hasStoredApiKey(AiModel|AiSourceProvider $resource): bool
+    {
+        return trim((string) ($resource->getRawOriginal('api_key') ?? '')) !== '';
+    }
+}

--- a/app/Services/GeoFlow/TitleAiGenerationService.php
+++ b/app/Services/GeoFlow/TitleAiGenerationService.php
@@ -22,7 +22,10 @@ class TitleAiGenerationService
     /**
      * 复用统一 API Key 解密组件，避免标题生成链路与其他 AI 链路出现差异。
      */
-    public function __construct(private readonly ApiKeyCrypto $apiKeyCrypto) {}
+    public function __construct(
+        private readonly ApiKeyCrypto $apiKeyCrypto,
+        private readonly AiUsageQuotaService $usageQuota,
+    ) {}
 
     /**
      * 生成标题列表。
@@ -41,10 +44,23 @@ class TitleAiGenerationService
         string $style,
         string $customPrompt = ''
     ): array {
+        $reservation = null;
+
         try {
+            $reservation = $this->usageQuota->reserveModel($aiModel);
+            if ($reservation === null) {
+                throw new \RuntimeException('ai_daily_limit_reached');
+            }
+
             $content = $this->requestTitlesFromModel($aiModel, $keywords, $count, $style, $customPrompt);
             $titles = $this->parseGeneratedTitles($content);
             if ($titles !== []) {
+                try {
+                    $this->usageQuota->recordModelSuccess($reservation);
+                } catch (Throwable $exception) {
+                    report($exception);
+                }
+
                 return [
                     'titles' => $titles,
                     'fallback_used' => false,
@@ -52,11 +68,19 @@ class TitleAiGenerationService
                 ];
             }
         } catch (Throwable $exception) {
+            if ($reservation instanceof AiUsageReservation) {
+                $this->usageQuota->releaseModel($reservation);
+            }
+
             return [
                 'titles' => $this->generateMockTitles($keywords, $count, $style),
                 'fallback_used' => true,
                 'fallback_reason' => $exception->getMessage(),
             ];
+        }
+
+        if ($reservation instanceof AiUsageReservation) {
+            $this->usageQuota->releaseModel($reservation);
         }
 
         return [

--- a/database/migrations/2026_07_26_000000_add_event_date_index_to_ai_visibility_runs.php
+++ b/database/migrations/2026_07_26_000000_add_event_date_index_to_ai_visibility_runs.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('ai_visibility_runs')) {
+            return;
+        }
+
+        Schema::table('ai_visibility_runs', function (Blueprint $table): void {
+            $table->index(
+                ['completed_at', 'created_at', 'status'],
+                'ai_visibility_runs_event_date_status_idx',
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('ai_visibility_runs')) {
+            return;
+        }
+
+        Schema::table('ai_visibility_runs', function (Blueprint $table): void {
+            $table->dropIndex('ai_visibility_runs_event_date_status_idx');
+        });
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1145,6 +1145,7 @@ return [
         'test_error_api_url_missing' => 'API URL is empty. Please enter the API Base URL first.',
         'test_error_api_key_missing' => 'API key is empty or cannot be decrypted. Please re-enter the key.',
         'test_error_model_missing' => 'Model ID is empty. Please enter the model ID first.',
+        'test_error_daily_limit' => 'This model has reached its daily call limit.',
         'test_failed_with_status' => 'HTTP :status, response: :message',
         'test_invalid_response' => 'The API returned an unrecognized format. Response preview: :message',
         'test_exception' => 'Request exception: :message',

--- a/lang/pt_BR/admin.php
+++ b/lang/pt_BR/admin.php
@@ -2454,6 +2454,7 @@ return array_replace_recursive($base, [
         'test_error_api_url_missing' => 'A URL da API está vazia. Informe primeiro a URL Base da API.',
         'test_error_api_key_missing' => 'A chave da API está vazia ou não pôde ser descriptografada. Informe a chave novamente.',
         'test_error_model_missing' => 'O ID do modelo está vazio. Informe primeiro o ID do modelo.',
+        'test_error_daily_limit' => 'Este modelo atingiu o limite diário de chamadas.',
         'test_failed_with_status' => 'HTTP :status, resposta: :message',
         'test_invalid_response' => 'A API retornou um formato não reconhecido. Prévia da resposta: :message',
         'test_exception' => 'Exceção na requisição: :message',

--- a/lang/zh_CN/admin.php
+++ b/lang/zh_CN/admin.php
@@ -1145,6 +1145,7 @@ return [
         'test_error_api_url_missing' => 'API 地址为空，请先填写 API Base URL',
         'test_error_api_key_missing' => 'API 密钥为空或无法解密，请重新填写密钥',
         'test_error_model_missing' => '模型 ID 为空，请先填写模型 ID',
+        'test_error_daily_limit' => '该模型已达到今日调用上限',
         'test_failed_with_status' => 'HTTP :status，返回：:message',
         'test_invalid_response' => '接口返回格式无法识别，返回片段：:message',
         'test_exception' => '请求异常：:message',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
         </include>
     </source>
     <php>
+        <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing" force="true"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -310,7 +310,9 @@ Route::prefix($adminPrefix)->name('admin.')->middleware(['admin.locale'])->group
                 Route::get('/', [AiModelController::class, 'index'])->name('index');
                 Route::post('create', [AiModelController::class, 'store'])->name('store');
                 Route::put('{modelId}', [AiModelController::class, 'update'])->name('update');
-                Route::post('{modelId}/test', [AiModelController::class, 'testConnection'])->name('test');
+                Route::post('{modelId}/test', [AiModelController::class, 'testConnection'])
+                    ->middleware('throttle:admin-sensitive')
+                    ->name('test');
                 Route::post('{modelId}/delete', [AiModelController::class, 'destroy'])->name('delete');
                 Route::post('default-embedding', [AiModelController::class, 'updateDefaultEmbedding'])->name('default-embedding');
                 Route::post('chunking-config', [AiModelController::class, 'updateChunkingConfig'])->name('chunking-config');

--- a/tests/Feature/AdminAiModelsPageTest.php
+++ b/tests/Feature/AdminAiModelsPageTest.php
@@ -37,9 +37,57 @@ class AdminAiModelsPageTest extends TestCase
             ->assertJsonPath('meta.model_type', 'chat')
             ->assertJsonPath('meta.http_status', 200);
 
+        $this->assertSame(now()->toDateString(), $model->fresh()->usage_date?->toDateString());
+        $this->assertSame(1, (int) $model->fresh()->used_today);
+        $this->assertSame(1, (int) $model->fresh()->total_used);
+
         Http::assertSent(fn ($request): bool => $request->url() === 'https://ai.test/v1/chat/completions'
             && $request['model'] === 'test-chat-model'
             && $request->hasHeader('Authorization', 'Bearer test-api-key'));
+    }
+
+    public function test_model_connection_tests_are_rate_limited(): void
+    {
+        Http::fake([
+            'https://ai.test/v1/chat/completions' => Http::response([
+                'choices' => [
+                    ['message' => ['content' => 'OK']],
+                ],
+            ]),
+        ]);
+
+        $admin = $this->createAdmin();
+        $model = $this->createAiModel('chat');
+
+        foreach (range(1, 5) as $attempt) {
+            $this->actingAs($admin, 'admin')
+                ->postJson(route('admin.ai-models.test', ['modelId' => (int) $model->id]))
+                ->assertOk();
+        }
+
+        $this->actingAs($admin, 'admin')
+            ->postJson(route('admin.ai-models.test', ['modelId' => (int) $model->id]))
+            ->assertTooManyRequests();
+    }
+
+    public function test_model_connection_test_stops_after_daily_quota_is_used(): void
+    {
+        Http::fake();
+        $model = $this->createAiModel('chat', [
+            'daily_limit' => 1,
+            'used_today' => 1,
+            'usage_date' => now()->toDateString(),
+        ]);
+
+        $this->actingAs($this->createAdmin(), 'admin')
+            ->postJson(route('admin.ai-models.test', ['modelId' => (int) $model->id]))
+            ->assertUnprocessable()
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('message', __('admin.ai_models.test_error_daily_limit'));
+
+        $this->assertSame(1, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
+        Http::assertNothingSent();
     }
 
     public function test_admin_models_page_shows_test_action(): void
@@ -51,6 +99,24 @@ class AdminAiModelsPageTest extends TestCase
 
         $response->assertOk()
             ->assertSee(__('admin.ai_models.test'));
+    }
+
+    public function test_admin_models_page_resets_usage_display_after_the_usage_date_changes(): void
+    {
+        $this->travelTo('2026-07-27 09:00:00');
+        $model = $this->createAiModel('chat', [
+            'used_today' => 9,
+            'usage_date' => '2026-07-26',
+        ]);
+
+        $response = $this->actingAs($this->createAdmin(), 'admin')
+            ->get(route('admin.ai-models.index'));
+
+        $modelRow = collect($response->viewData('models'))
+            ->firstWhere('id', (int) $model->id);
+
+        $response->assertOk();
+        $this->assertSame(0, (int) ($modelRow['used_today'] ?? -1));
     }
 
     public function test_admin_models_page_works_before_max_tokens_migration_runs(): void
@@ -335,6 +401,9 @@ class AdminAiModelsPageTest extends TestCase
             ->assertStatus(422)
             ->assertJsonPath('success', false)
             ->assertJsonPath('meta.http_status', 401);
+
+        $this->assertSame(0, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
     }
 
     private function createAdmin(): Admin

--- a/tests/Feature/AdminAiVisibilityAnalyticsTest.php
+++ b/tests/Feature/AdminAiVisibilityAnalyticsTest.php
@@ -121,6 +121,23 @@ class AdminAiVisibilityAnalyticsTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_configuration_status_rejects_a_search_provider_on_an_untrusted_endpoint(): void
+    {
+        AiSourceProvider::query()->create([
+            'name' => 'Untrusted Search',
+            'provider_key' => AiSourceProvider::PROVIDER_DOUBAO_SEARCH_CUSTOM,
+            'endpoint_url' => 'https://attacker.example.com/search',
+            'api_key' => 'stored-key',
+            'daily_limit' => 10,
+            'status' => 'active',
+        ]);
+
+        $overview = app(AiVisibilityAnalyticsService::class)->overview();
+
+        $this->assertFalse($overview['configured']);
+        $this->assertFalse($overview['configuration']['doubao_search_configured']);
+    }
+
     public function test_ai_visibility_analytics_caps_daily_keyword_samples_at_five(): void
     {
         Carbon::setTestNow(Carbon::parse('2026-07-10 12:00:00'));
@@ -145,10 +162,16 @@ class AdminAiVisibilityAnalyticsTest extends TestCase
             );
         }
 
+        $retrievedRunIds = [];
+        AiVisibilityRun::retrieved(function (AiVisibilityRun $run) use (&$retrievedRunIds): void {
+            $retrievedRunIds[] = (int) $run->id;
+        });
+
         $overview = app(AiVisibilityAnalyticsService::class)->overview();
 
         $this->assertSame(6, $overview['polling']['completed_runs']);
         $this->assertSame(5, $overview['polling']['sampled_runs']);
+        $this->assertCount(5, array_unique($retrievedRunIds));
         $this->assertSame(0.0, $overview['kpis']['brand_visibility']);
         $this->assertSame(0.0, $overview['kpis']['top1_rate']);
 

--- a/tests/Feature/AdminAnalyticsPageTest.php
+++ b/tests/Feature/AdminAnalyticsPageTest.php
@@ -164,6 +164,46 @@ class AdminAnalyticsPageTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_analytics_reports_only_usage_recorded_for_the_current_day(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-07-27 12:00:00'));
+
+        AiModel::query()->create([
+            'name' => 'Yesterday Model',
+            'model_id' => 'yesterday-model',
+            'model_type' => 'chat',
+            'used_today' => 9,
+            'usage_date' => '2026-07-26',
+            'total_used' => 20,
+            'status' => 'active',
+        ]);
+        AiModel::query()->create([
+            'name' => 'Today Model',
+            'model_id' => 'today-model',
+            'model_type' => 'chat',
+            'used_today' => 3,
+            'usage_date' => '2026-07-27',
+            'total_used' => 10,
+            'status' => 'active',
+        ]);
+
+        $response = $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.analytics'));
+
+        $response->assertOk();
+        $this->assertSame(3, (int) $response->viewData('kpis')['ai_calls']);
+        $this->assertSame(3, (int) $response->viewData('aiUsageSummary')['used_today']);
+        $this->assertSame(3, (int) $response->viewData('aiHealth')['used_today']);
+
+        $usageRows = collect($response->viewData('aiUsageSummary')['model_rows']);
+        $this->assertSame(
+            0,
+            (int) $usageRows->firstWhere('model_id', 'yesterday-model')->used_today
+        );
+
+        Carbon::setTestNow();
+    }
+
     public function test_analytics_filter_presets_and_custom_dates_are_usable(): void
     {
         Carbon::setTestNow(Carbon::parse('2026-05-21 12:00:00'));
@@ -657,6 +697,7 @@ class AdminAnalyticsPageTest extends TestCase
             'model_type' => 'chat',
             'api_url' => 'https://api.example.com',
             'used_today' => 9,
+            'usage_date' => Carbon::parse('2026-05-21')->toDateString(),
             'total_used' => 18,
             'status' => 'active',
         ]);

--- a/tests/Feature/AiUsageQuotaServiceTest.php
+++ b/tests/Feature/AiUsageQuotaServiceTest.php
@@ -6,6 +6,7 @@ use App\Models\AiModel;
 use App\Models\AiSourceProvider;
 use App\Services\GeoFlow\AiUsageQuotaService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class AiUsageQuotaServiceTest extends TestCase
@@ -63,6 +64,56 @@ class AiUsageQuotaServiceTest extends TestCase
         $this->assertSame(1, (int) $provider->fresh()->used_today);
         $quota->recordProviderSuccess($newReservation);
         $this->assertSame(1, (int) $provider->fresh()->total_used);
+    }
+
+    public function test_a_model_reservation_can_only_be_finalized_once(): void
+    {
+        $model = $this->createModel();
+        $model->update(['daily_limit' => 2]);
+        $quota = app(AiUsageQuotaService::class);
+
+        $releasedReservation = $quota->reserveModel($model);
+        $successfulReservation = $quota->reserveModel($model);
+        $this->assertNotNull($releasedReservation);
+        $this->assertNotNull($successfulReservation);
+        $this->assertSame(2, (int) $model->fresh()->used_today);
+
+        $quota->releaseModel($releasedReservation);
+        $quota->releaseModel($releasedReservation);
+        $quota->recordModelSuccess($releasedReservation);
+
+        $this->assertSame(1, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
+
+        $quota->recordModelSuccess($successfulReservation);
+        $quota->recordModelSuccess($successfulReservation);
+        $quota->releaseModel($successfulReservation);
+
+        $this->assertSame(1, (int) $model->fresh()->used_today);
+        $this->assertSame(1, (int) $model->fresh()->total_used);
+    }
+
+    public function test_a_rolled_back_success_can_still_release_the_reserved_usage(): void
+    {
+        $model = $this->createModel();
+        $quota = app(AiUsageQuotaService::class);
+        $reservation = $quota->reserveModel($model);
+        $this->assertNotNull($reservation);
+
+        try {
+            DB::transaction(function () use ($quota, $reservation): void {
+                $quota->recordModelSuccess($reservation);
+
+                throw new \RuntimeException('rollback');
+            });
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('rollback', $exception->getMessage());
+        }
+
+        $quota->releaseModel($reservation);
+
+        $this->assertSame(0, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
     }
 
     private function createModel(): AiModel

--- a/tests/Feature/TitleAiGenerationServiceTest.php
+++ b/tests/Feature/TitleAiGenerationServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AiModel;
+use App\Services\GeoFlow\TitleAiGenerationService;
+use App\Support\GeoFlow\ApiKeyCrypto;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Ai\AnonymousAgent;
+use Tests\TestCase;
+
+class TitleAiGenerationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_title_generation_uses_fallback_without_calling_a_model_after_daily_quota_is_used(): void
+    {
+        AnonymousAgent::fake(['真实模型标题'])->preventStrayPrompts();
+        $model = $this->createModel([
+            'daily_limit' => 1,
+            'used_today' => 1,
+            'usage_date' => now()->toDateString(),
+        ]);
+
+        $result = app(TitleAiGenerationService::class)->generateTitles(
+            $model,
+            ['GEO 内容工程'],
+            1,
+            'professional',
+        );
+
+        $this->assertTrue($result['fallback_used']);
+        $this->assertSame(1, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
+        AnonymousAgent::assertNeverPrompted();
+    }
+
+    public function test_successful_title_generation_records_daily_and_total_usage(): void
+    {
+        AnonymousAgent::fake(["GEO 标题一\nGEO 标题二"])->preventStrayPrompts();
+        $model = $this->createModel();
+
+        $result = app(TitleAiGenerationService::class)->generateTitles(
+            $model,
+            ['GEO 内容工程'],
+            2,
+            'professional',
+        );
+
+        $this->assertFalse($result['fallback_used']);
+        $this->assertSame(['GEO 标题一', 'GEO 标题二'], $result['titles']);
+        $this->assertSame(now()->toDateString(), $model->fresh()->usage_date?->toDateString());
+        $this->assertSame(1, (int) $model->fresh()->used_today);
+        $this->assertSame(1, (int) $model->fresh()->total_used);
+    }
+
+    public function test_failed_title_generation_releases_the_reserved_daily_usage(): void
+    {
+        AnonymousAgent::fake([''])->preventStrayPrompts();
+        $model = $this->createModel(['daily_limit' => 1]);
+
+        $result = app(TitleAiGenerationService::class)->generateTitles(
+            $model,
+            ['GEO 内容工程'],
+            1,
+            'professional',
+        );
+
+        $this->assertTrue($result['fallback_used']);
+        $this->assertSame(0, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
+    }
+
+    private function createModel(array $overrides = []): AiModel
+    {
+        return AiModel::query()->create(array_merge([
+            'name' => 'Title Model',
+            'version' => 'test',
+            'api_key' => app(ApiKeyCrypto::class)->encrypt('title-test-key'),
+            'model_id' => 'title-model',
+            'model_type' => 'chat',
+            'api_url' => 'https://ai.test/v1',
+            'daily_limit' => 10,
+            'used_today' => 0,
+            'total_used' => 0,
+            'status' => 'active',
+        ], $overrides));
+    }
+}

--- a/tests/Unit/TestRunnerMemoryConfigurationTest.php
+++ b/tests/Unit/TestRunnerMemoryConfigurationTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class TestRunnerMemoryConfigurationTest extends TestCase
+{
+    public function test_phpunit_uses_the_project_memory_limit(): void
+    {
+        $this->assertSame('512M', ini_get('memory_limit'));
+    }
+}


### PR DESCRIPTION
## Summary

- make AI usage counters date-aware and enforce quota reservations for title generation and model connection tests
- make reservations one-shot and transaction-safe, with sensitive-route throttling
- unify AI visibility provider readiness with trusted endpoint policy and move analytics sampling into the database
- add the supporting analytics index and a stable PHPUnit memory-limit regression guard

## Root cause

Several AI entry points and usage summaries had grown around the shared quota service, which left inconsistent daily accounting and retry behavior. AI visibility readiness and analytics also duplicated provider rules and hydrated more records than required. The previous test-memory setting was applied to the Artisan parent process, while Collision starts PHPUnit as a child process; `phpunit.xml` now owns that invariant.

## Impact

Daily limits and usage displays remain accurate across day boundaries, retries cannot finalize the same reservation twice, untrusted AI visibility endpoints are rejected consistently, and analytics loads only sampled runs. The standard test command now remains stable for the full suite.

## Verification

- `composer test` — 1048 passed, 8472 assertions
- `npm run build` — passed
- `composer validate --strict` — passed
- changed PHP files: Pint passed
- Gitleaks diff scan: no leaks found
