### PR TITLE
feat: add Atlas Cloud model preset

### DIFF
--- a/app/Http/Controllers/Admin/AiModelController.php
+++ b/app/Http/Controllers/Admin/AiModelController.php
@@ -8,6 +8,7 @@ use App\Models\Article;
 use App\Models\SiteSetting;
 use App\Services\GeoFlow\AiUsageQuotaService;
 use App\Services\GeoFlow\AiUsageReservation;
+use App\Services\GeoFlow\AiVisibility\AiProviderEndpointPolicy;
 use App\Services\Outbound\SafeOutboundHttpClient;
 use App\Support\AdminWeb;
 use App\Support\GeoFlow\ApiKeyCrypto;
@@ -40,6 +41,7 @@ class AiModelController extends Controller
         private readonly SafeOutboundHttpClient $safeHttp,
         private readonly Factory $http,
         private readonly AiUsageQuotaService $usageQuota,
+        private readonly AiProviderEndpointPolicy $endpointPolicy,
     ) {}
 
     /**
@@ -145,6 +147,18 @@ class AiModelController extends Controller
         }
 
         $apiKey = trim((string) ($payload['api_key'] ?? ''));
+        $currentApiUrl = trim((string) ($model->api_url ?? ''));
+        $nextApiUrl = (string) $updateData['api_url'];
+        if ($apiKey === ''
+            && $currentApiUrl !== $nextApiUrl
+            && ! $this->endpointPolicy->sameOrigin($currentApiUrl, $nextApiUrl)) {
+            return back()
+                ->withInput($request->except('api_key'))
+                ->withErrors([
+                    'api_key' => __('admin.ai_models.error.api_key_required_for_origin_change'),
+                ]);
+        }
+
         if ($apiKey !== '') {
             try {
                 $updateData['api_key'] = $this->encryptApiKey($apiKey);

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1184,6 +1184,7 @@ return [
         'failover_priority_help' => 'Lower numbers are tried first as fallback models. The primary model is always attempted first; failover only starts after it fails.',
         'api_key_help_create' => 'Required when creating a model.',
         'api_key_help_edit' => 'Leave blank while editing to keep the current key. Enter a new value only when rotating credentials.',
+        'api_key_help_origin_change' => 'The API provider changed. Enter a key issued for the new provider before saving.',
         'confirm_delete' => 'Delete model ":name"? This action cannot be undone.',
         'error' => [
             'required_fields' => 'Model name, API key, and model ID are required',
@@ -1195,6 +1196,7 @@ return [
             'chunking_model_unavailable' => 'The selected semantic chunking model is unavailable',
             'chunking_model_required' => 'LLM semantic planning requires an available chat model',
             'crypto_key_missing' => 'APP_KEY is not configured, so API keys cannot be encrypted and saved',
+            'api_key_required_for_origin_change' => 'Enter a new API key when changing the API provider',
         ],
         'message' => [
             'create_success' => 'AI model created successfully',

--- a/lang/pt_BR/admin.php
+++ b/lang/pt_BR/admin.php
@@ -2422,6 +2422,7 @@ return array_replace_recursive($base, [
             'chunking_model_unavailable' => 'Modelo de fragmentação semântica indisponível',
             'chunking_model_required' => 'Planejamento semântico por LLM exige um modelo de chat disponível',
             'crypto_key_missing' => 'APP_KEY não configurado',
+            'api_key_required_for_origin_change' => 'Informe uma nova chave de API ao alterar o provedor',
         ],
         'message' => [
             'create_success' => 'Modelo criado com sucesso',
@@ -2465,6 +2466,7 @@ return array_replace_recursive($base, [
         'failover_priority_help' => 'Números menores são tentados primeiro como modelos de fallback. O modelo principal sempre é tentado primeiro; o fallback só começa depois de uma falha.',
         'api_key_help_create' => 'Obrigatório ao criar um modelo.',
         'api_key_help_edit' => 'Ao editar, deixe em branco para manter a chave atual. Informe um novo valor apenas ao trocar credenciais.',
+        'api_key_help_origin_change' => 'O provedor da API foi alterado. Informe uma chave emitida pelo novo provedor antes de salvar.',
     ],
     'ai_source_providers' => [
         'page_title' => 'Configuração de Busca de IA e Fontes',

--- a/lang/zh_CN/admin.php
+++ b/lang/zh_CN/admin.php
@@ -1184,6 +1184,7 @@ return [
         'failover_priority_help' => '数值越小，越优先作为智能模型切换的后备模型。主模型始终先尝试，只有失败时才按优先级切换。',
         'api_key_help_create' => '创建模型时必填。',
         'api_key_help_edit' => '编辑时留空即可保留现有密钥；仅在需要轮换密钥时填写新值。',
+        'api_key_help_origin_change' => 'API 服务商已变更，保存前必须填写新服务商签发的 API Key。',
         'confirm_delete' => '确定要删除模型“:name”吗？此操作不可恢复。',
         'error' => [
             'required_fields' => '模型名称、API密钥和模型ID不能为空',
@@ -1195,6 +1196,7 @@ return [
             'chunking_model_unavailable' => '所选语义切片模型不可用',
             'chunking_model_required' => '选择 LLM 语义规划时必须指定一个可用的聊天模型',
             'crypto_key_missing' => '系统未配置 APP_KEY（应用密钥），无法加密保存 API 密钥',
+            'api_key_required_for_origin_change' => '更换 API 服务商时必须填写新的 API Key',
         ],
         'message' => [
             'create_success' => 'AI模型创建成功',

--- a/resources/views/admin/ai-models/index.blade.php
+++ b/resources/views/admin/ai-models/index.blade.php
@@ -227,6 +227,7 @@
                             <button type="button" onclick="fillPreset('minimax_m27')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">MiniMax M2.7</button>
                             <button type="button" onclick="fillPreset('minimax_highspeed')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">MiniMax Highspeed</button>
                             <button type="button" onclick="fillPreset('openai')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">OpenAI</button>
+                            <button type="button" onclick="fillPreset('atlascloud')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">Atlas Cloud</button>
                             <button type="button" onclick="fillPreset('gemini')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">Gemini</button>
                             <button type="button" onclick="fillPreset('deepseek')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">DeepSeek V4 Flash</button>
                             <button type="button" onclick="fillPreset('deepseek_v4_pro')" class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50">DeepSeek V4 Pro</button>
@@ -346,6 +347,7 @@
             minimax_m27: {name: 'MiniMax M2.7', version: 'M2.7', model_id: 'MiniMax-M2.7', api_url: 'https://api.minimax.io', model_type: 'chat'},
             minimax_highspeed: {name: 'MiniMax M2.7 Highspeed', version: 'M2.7', model_id: 'MiniMax-M2.7-highspeed', api_url: 'https://api.minimax.io', model_type: 'chat'},
             openai: {name: 'GPT-4o', version: '', model_id: 'gpt-4o', api_url: 'https://api.openai.com', model_type: 'chat'},
+            atlascloud: {name: 'Atlas Cloud DeepSeek V4 Pro', version: 'v4', model_id: 'deepseek-ai/deepseek-v4-pro', api_url: 'https://api.atlascloud.ai/v1', model_type: 'chat'},
             gemini: {name: 'Gemini 3 Flash Preview', version: 'v1beta', model_id: 'gemini-3-flash-preview', api_url: 'https://generativelanguage.googleapis.com/v1beta', model_type: 'chat'},
             deepseek: {name: 'DeepSeek V4 Flash', version: 'v4', model_id: 'deepseek-v4-flash', api_url: 'https://api.deepseek.com', model_type: 'chat'},
             deepseek_v4_pro: {name: 'DeepSeek V4 Pro', version: 'v4', model_id: 'deepseek-v4-pro', api_url: 'https://api.deepseek.com', model_type: 'chat'},

--- a/resources/views/admin/ai-models/index.blade.php
+++ b/resources/views/admin/ai-models/index.blade.php
@@ -330,6 +330,7 @@
             apiKeyPlaceholderKeep: @json(__('admin.ai_models.placeholder_api_key_keep')),
             apiKeyHelpCreate: @json(__('admin.ai_models.api_key_help_create')),
             apiKeyHelpEdit: @json(__('admin.ai_models.api_key_help_edit')),
+            apiKeyHelpOriginChange: @json(__('admin.ai_models.api_key_help_origin_change')),
             confirmDelete: @json(__('admin.ai_models.confirm_delete', ['name' => '__NAME__'])),
             test: @json(__('admin.ai_models.test')),
             testing: @json(__('admin.ai_models.testing')),
@@ -370,7 +371,9 @@
             document.getElementById('api_key').required = true;
             document.getElementById('api_key').placeholder = AI_MODELS_I18N.apiKeyPlaceholder;
             document.getElementById('apiKeyHelp').textContent = AI_MODELS_I18N.apiKeyHelpCreate;
-            document.getElementById('api_url').value = 'https://api.deepseek.com';
+            const apiUrlField = document.getElementById('api_url');
+            apiUrlField.value = 'https://api.deepseek.com';
+            apiUrlField.dataset.originalOrigin = '';
             document.getElementById('failover_priority').value = 100;
             syncMaxTokensVisibility();
             document.getElementById('modelModal').classList.remove('hidden');
@@ -389,7 +392,9 @@
             document.getElementById('api_key').required = false;
             document.getElementById('api_key').placeholder = AI_MODELS_I18N.apiKeyPlaceholderKeep;
             document.getElementById('apiKeyHelp').textContent = AI_MODELS_I18N.apiKeyHelpEdit;
-            document.getElementById('api_url').value = model.api_url || '';
+            const apiUrlField = document.getElementById('api_url');
+            apiUrlField.value = model.api_url || '';
+            apiUrlField.dataset.originalOrigin = providerOrigin(apiUrlField.value);
             document.getElementById('failover_priority').value = model.failover_priority || 100;
             document.getElementById('daily_limit').value = model.daily_limit || 0;
             document.getElementById('max_tokens').value = model.max_tokens ?? '';
@@ -471,13 +476,47 @@
             if (!preset) {
                 return;
             }
+            const apiUrlField = document.getElementById('api_url');
+            const apiKeyField = document.getElementById('api_key');
+            if (document.getElementById('formMethod').value === 'PUT'
+                && providerOrigin(apiUrlField.value) !== providerOrigin(preset.api_url)) {
+                apiKeyField.value = '';
+            }
             document.getElementById('name').value = preset.name;
             document.getElementById('version').value = preset.version;
             document.getElementById('model_id').value = preset.model_id;
-            document.getElementById('api_url').value = preset.api_url;
+            apiUrlField.value = preset.api_url;
             document.getElementById('model_type').value = preset.model_type;
+            syncApiKeyRequirement();
             syncMaxTokensVisibility();
         }
+
+        function providerOrigin(value) {
+            try {
+                return new URL(String(value || '').trim()).origin.toLowerCase();
+            } catch (error) {
+                return String(value || '').trim().toLowerCase();
+            }
+        }
+
+        function syncApiKeyRequirement() {
+            if (document.getElementById('formMethod').value !== 'PUT') {
+                return;
+            }
+
+            const apiUrlField = document.getElementById('api_url');
+            const apiKeyField = document.getElementById('api_key');
+            const providerChanged = (apiUrlField.dataset.originalOrigin || '') !== providerOrigin(apiUrlField.value);
+            apiKeyField.required = providerChanged;
+            apiKeyField.placeholder = providerChanged
+                ? AI_MODELS_I18N.apiKeyPlaceholder
+                : AI_MODELS_I18N.apiKeyPlaceholderKeep;
+            document.getElementById('apiKeyHelp').textContent = providerChanged
+                ? AI_MODELS_I18N.apiKeyHelpOriginChange
+                : AI_MODELS_I18N.apiKeyHelpEdit;
+        }
+
+        document.getElementById('api_url')?.addEventListener('input', syncApiKeyRequirement);
 
         function syncMaxTokensVisibility() {
             const field = document.getElementById('maxTokensField');

--- a/tests/Feature/AdminAiModelsPageTest.php
+++ b/tests/Feature/AdminAiModelsPageTest.php
@@ -46,6 +46,36 @@ class AdminAiModelsPageTest extends TestCase
             && $request->hasHeader('Authorization', 'Bearer test-api-key'));
     }
 
+    public function test_admin_can_test_atlas_cloud_chat_model_connection(): void
+    {
+        Http::fake([
+            'https://api.atlascloud.ai/v1/chat/completions' => Http::response([
+                'choices' => [
+                    ['message' => ['content' => 'OK']],
+                ],
+            ]),
+        ]);
+
+        $model = $this->createAiModel('chat', [
+            'name' => 'Atlas Cloud DeepSeek V4 Pro',
+            'model_id' => 'deepseek-ai/deepseek-v4-pro',
+            'api_url' => 'https://api.atlascloud.ai/v1',
+        ]);
+
+        $response = $this->actingAs($this->createAdmin(), 'admin')
+            ->postJson(route('admin.ai-models.test', ['modelId' => (int) $model->id]));
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('meta.model_type', 'chat')
+            ->assertJsonPath('meta.http_status', 200);
+
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://api.atlascloud.ai/v1/chat/completions'
+            && $request['model'] === 'deepseek-ai/deepseek-v4-pro'
+            && $request->hasHeader('Authorization', 'Bearer test-api-key'));
+    }
+
     public function test_model_connection_tests_are_rate_limited(): void
     {
         Http::fake([
@@ -343,6 +373,9 @@ class AdminAiModelsPageTest extends TestCase
             ->assertSee('MiniMax-M2.7-highspeed', false)
             ->assertSee('deepseek-v4-flash', false)
             ->assertSee('DeepSeek V4 Pro', false)
+            ->assertSee('Atlas Cloud', false)
+            ->assertSee('deepseek-ai/deepseek-v4-pro', false)
+            ->assertSee('https://api.atlascloud.ai/v1', false)
             ->assertSee('Gemini', false)
             ->assertSee('Gemini Embedding', false)
             ->assertSee('Doubao Embedding', false)

--- a/tests/Feature/AdminAiModelsPageTest.php
+++ b/tests/Feature/AdminAiModelsPageTest.php
@@ -201,6 +201,96 @@ class AdminAiModelsPageTest extends TestCase
         $this->assertNull(AiModel::query()->where('model_id', 'embedding-model')->value('max_tokens'));
     }
 
+    public function test_admin_must_rotate_api_key_when_model_origin_changes(): void
+    {
+        $model = $this->createAiModel('chat', [
+            'api_url' => 'https://api.openai.com',
+        ]);
+        $originalEncryptedKey = (string) $model->getRawOriginal('api_key');
+
+        $response = $this->actingAs($this->createAdmin(), 'admin')
+            ->from(route('admin.ai-models.index'))
+            ->put(route('admin.ai-models.update', ['modelId' => (int) $model->id]), [
+                'name' => 'Atlas Cloud DeepSeek V4 Pro',
+                'version' => 'v4',
+                'api_key' => '',
+                'model_id' => 'deepseek-ai/deepseek-v4-pro',
+                'model_type' => 'chat',
+                'api_url' => 'https://api.atlascloud.ai/v1',
+                'failover_priority' => 100,
+                'daily_limit' => 0,
+                'status' => 'active',
+            ]);
+
+        $response
+            ->assertRedirect(route('admin.ai-models.index'))
+            ->assertSessionHasErrors('api_key');
+
+        $model->refresh();
+        $this->assertSame('https://api.openai.com', $model->api_url);
+        $this->assertSame($originalEncryptedKey, (string) $model->getRawOriginal('api_key'));
+    }
+
+    public function test_admin_can_keep_api_key_when_only_model_endpoint_path_changes(): void
+    {
+        $model = $this->createAiModel('chat', [
+            'api_url' => 'https://api.openai.com',
+        ]);
+        $originalEncryptedKey = (string) $model->getRawOriginal('api_key');
+
+        $response = $this->actingAs($this->createAdmin(), 'admin')
+            ->put(route('admin.ai-models.update', ['modelId' => (int) $model->id]), [
+                'name' => 'OpenAI Chat',
+                'version' => '',
+                'api_key' => '',
+                'model_id' => 'gpt-4o',
+                'model_type' => 'chat',
+                'api_url' => 'https://api.openai.com/v1',
+                'failover_priority' => 100,
+                'daily_limit' => 0,
+                'status' => 'active',
+            ]);
+
+        $response
+            ->assertRedirect(route('admin.ai-models.index'))
+            ->assertSessionHasNoErrors();
+
+        $model->refresh();
+        $this->assertSame('https://api.openai.com/v1', $model->api_url);
+        $this->assertSame($originalEncryptedKey, (string) $model->getRawOriginal('api_key'));
+    }
+
+    public function test_admin_can_rotate_api_key_when_model_origin_changes(): void
+    {
+        $model = $this->createAiModel('chat', [
+            'api_url' => 'https://api.openai.com',
+        ]);
+
+        $response = $this->actingAs($this->createAdmin(), 'admin')
+            ->put(route('admin.ai-models.update', ['modelId' => (int) $model->id]), [
+                'name' => 'Atlas Cloud DeepSeek V4 Pro',
+                'version' => 'v4',
+                'api_key' => 'atlas-cloud-api-key',
+                'model_id' => 'deepseek-ai/deepseek-v4-pro',
+                'model_type' => 'chat',
+                'api_url' => 'https://api.atlascloud.ai/v1',
+                'failover_priority' => 100,
+                'daily_limit' => 0,
+                'status' => 'active',
+            ]);
+
+        $response
+            ->assertRedirect(route('admin.ai-models.index'))
+            ->assertSessionHasNoErrors();
+
+        $model->refresh();
+        $this->assertSame('https://api.atlascloud.ai/v1', $model->api_url);
+        $this->assertSame(
+            'atlas-cloud-api-key',
+            app(ApiKeyCrypto::class)->decrypt((string) $model->getRawOriginal('api_key'))
+        );
+    }
+
     public function test_admin_can_test_embedding_model_connection(): void
     {
         Http::fake([


### PR DESCRIPTION
## Summary

- add an Atlas Cloud quick-fill option to the existing AI model configuration modal
- prefill the OpenAI-compatible base URL and `deepseek-ai/deepseek-v4-pro` model ID
- cover preset rendering and the existing Chat Completions connection-test path

The preset reuses GEOFlow's existing encrypted API key storage, outbound request policy, usage quota, and OpenAI-compatible `/chat/completions` runtime.

## Validation

- executable Node assertion parsed `PROVIDER_PRESETS` and verified the Atlas Cloud values
- both Atlas Cloud model catalog endpoints returned HTTP 200 and included `deepseek-ai/deepseek-v4-pro`
- `git diff --check` passed
- secret and unrelated README/docs/logo/sponsor/credits/partner path scans passed
- focused PHPUnit tests were not run locally because PHP 8.3 is unavailable and the Docker daemon is not running; the PR includes focused feature coverage for CI

## Compliance

No README, docs, logo, sponsor, credits, or partner changes.