### PR TITLE
fix: equalize analytics overview card widths

### DIFF
--- a/resources/views/admin/analytics/index.blade.php
+++ b/resources/views/admin/analytics/index.blade.php
@@ -15,7 +15,7 @@
         [
             'key' => 'content',
             'route' => 'admin.analytics.content',
-            'span' => 'lg:col-span-7',
+            'span' => 'lg:col-span-6',
             'tone' => 'bg-blue-600',
             'icon' => 'files',
             'main' => (int) ($cards['content']['published'] ?? 0),
@@ -29,7 +29,7 @@
         [
             'key' => 'traffic',
             'route' => 'admin.analytics.traffic',
-            'span' => 'lg:col-span-5',
+            'span' => 'lg:col-span-6',
             'tone' => 'bg-cyan-600',
             'icon' => 'waypoints',
             'main' => (int) ($cards['traffic']['pv'] ?? 0),
@@ -43,7 +43,7 @@
         [
             'key' => 'ai_visibility',
             'route' => 'admin.analytics.ai-visibility',
-            'span' => 'lg:col-span-5',
+            'span' => 'lg:col-span-6',
             'tone' => 'bg-violet-600',
             'icon' => 'scan-search',
             'main' => number_format((float) ($cards['ai_visibility']['visibility'] ?? 0), 1).'%',
@@ -57,7 +57,7 @@
         [
             'key' => 'leads',
             'route' => 'admin.analytics.leads',
-            'span' => 'lg:col-span-7',
+            'span' => 'lg:col-span-6',
             'tone' => 'bg-amber-500',
             'icon' => 'contact-round',
             'main' => (int) ($cards['leads']['submissions_30d'] ?? 0),

--- a/tests/Feature/AdminAnalyticsNavigationTest.php
+++ b/tests/Feature/AdminAnalyticsNavigationTest.php
@@ -35,6 +35,10 @@ class AdminAnalyticsNavigationTest extends TestCase
             ->assertDontSee('data-ai-visibility-series', false)
             ->assertDontSee('data-analytics-health-grid', false);
 
+        $this->assertSame(4, substr_count($response->getContent(), 'lg:col-span-6'));
+        $this->assertStringNotContainsString('lg:col-span-5', $response->getContent());
+        $this->assertStringNotContainsString('lg:col-span-7', $response->getContent());
+
         foreach (['content', 'traffic', 'ai-visibility', 'leads', 'distribution'] as $page) {
             $this->get(route("admin.analytics.{$page}"))->assertOk();
         }


### PR DESCRIPTION
## Summary

- make the four primary analytics overview cards use equal 6/12 desktop columns
- keep the distribution card full width and preserve the mobile single-column layout
- add regression assertions that reject the previous 5/7 column split

## Verification

- `composer test` (1161 tests, 9135 assertions)
- `npm run build`
- `./vendor/bin/pint --test tests/Feature/AdminAnalyticsNavigationTest.php`
- `git diff --check`