### PR TITLE
feat: 首次安装提供百度统计示例代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ php artisan key:generate
 # 3. 数据库与存储
 GEOFLOW_SECURITY_FRESH_INSTALL_CONFIRMED=true php artisan migrate --force
 php artisan geoflow:install                                            # 首次空库安装
-# 可选极简安装：php artisan geoflow:install --without-demo
+# 跳过主题与参考文章，保留首装基础设置：php artisan geoflow:install --without-demo
 php artisan storage:link
 
 # 4. 开发用 HTTP（仅本地调试；生产请用 Nginx + PHP-FPM，站点根目录 public/）
@@ -352,7 +352,7 @@ chmod -R ug+rwx storage bootstrap/cache
 | 用户名 | `GEOFLOW_ADMIN_USERNAME`，默认 `admin` |
 | 密码 | 本地开发默认 `password`；生产环境请设置 `GEOFLOW_ADMIN_PASSWORD`。若生产环境留空且账号尚不存在，首次安装会生成一次性随机密码并输出到初始化日志 |
 
-补充规则：`geoflow:install` 在空库首次安装时写入默认管理员、21 号主题和 50 篇参考内容；`--without-demo` 会只创建管理员。检测到线上业务数据时，命令会记录安装标记，并保留已有主题、站点设置、作者、分类和文章。`AdminUserSeeder` 本身保持幂等：目标用户名已存在时不会覆盖用户名、邮箱或密码。
+补充规则：`geoflow:install` 在空库首次安装时写入默认管理员、21 号主题、50 篇参考内容和示例百度统计代码；`--without-demo` 会跳过 21 号主题与 50 篇参考内容，同时保留管理员和示例统计代码。该示例会立即从 `hm.baidu.com` 加载脚本，并将前台访问数据发送到示例百度统计账号；生产上线前请在“站点设置 → 统计代码”中替换为自己的统计代码，或清空后关闭。检测到线上业务数据时，命令会记录安装标记，并保留已有主题、站点设置、作者、分类、文章和统计代码。`AdminUserSeeder` 本身保持幂等：目标用户名已存在时不会覆盖用户名、邮箱或密码。
 
 50 篇参考文档位于 `database/seeders/data/frontend-reference-v1/`，其分类、元数据、首次安装和升级保护说明见 [`docs/reference/frontend-reference-content.md`](docs/reference/frontend-reference-content.md)。
 

--- a/app/Console/Commands/GeoFlowInstallCommand.php
+++ b/app/Console/Commands/GeoFlowInstallCommand.php
@@ -20,7 +20,7 @@ class GeoFlowInstallCommand extends Command
 
     protected $signature = 'geoflow:install
         {--force : Run first-install seeders even if an installation marker or existing data is present}
-        {--without-demo : Create only the administrator on a fresh install and skip the frontend reference pack}';
+        {--without-demo : Skip the frontend reference pack on a fresh install}';
 
     protected $description = 'Initialize GEOFlow once, including the default frontend reference pack on a fresh database';
 
@@ -108,12 +108,8 @@ class GeoFlowInstallCommand extends Command
                     throw new RuntimeException('Frontend reference seeding returned a failure status.');
                 }
 
-                if ($isPristineDatabase && $seedFrontendReference) {
-                    SiteSetting::query()->updateOrCreate(
-                        ['setting_key' => 'active_theme'],
-                        ['setting_value' => 'geoflow-template-21-enterprise-signature'],
-                    );
-                    SiteSettingsBag::forget();
+                if ($isPristineDatabase) {
+                    $this->seedInitialSiteSettings($seedFrontendReference);
                 }
 
                 $this->markInstalled($force ? 'forced_install' : 'fresh_install', [
@@ -173,6 +169,23 @@ class GeoFlowInstallCommand extends Command
         }
 
         return DB::table($table)->limit(1)->exists();
+    }
+
+    private function seedInitialSiteSettings(bool $seedFrontendReference): void
+    {
+        SiteSetting::query()->firstOrCreate(
+            ['setting_key' => 'analytics_code'],
+            ['setting_value' => (string) config('geoflow.default_analytics_code', '')],
+        );
+
+        if ($seedFrontendReference) {
+            SiteSetting::query()->updateOrCreate(
+                ['setting_key' => 'active_theme'],
+                ['setting_value' => 'geoflow-template-21-enterprise-signature'],
+            );
+        }
+
+        SiteSettingsBag::forget();
     }
 
     /**

--- a/config/geoflow.php
+++ b/config/geoflow.php
@@ -16,6 +16,17 @@ $versionManifest = is_file($versionManifestPath)
     : [];
 $appVersion = is_array($versionManifest) ? trim((string) ($versionManifest['version'] ?? '')) : '';
 $appVersion = $appVersion !== '' ? $appVersion : '0.0.0-dev';
+$defaultAnalyticsCode = <<<'HTML'
+<script>
+var _hmt = _hmt || [];
+(function() {
+  var hm = document.createElement("script");
+  hm.src = "https://hm.baidu.com/hm.js?1743638f313788caa4cb55e299444a87";
+  var s = document.getElementsByTagName("script")[0];
+  s.parentNode.insertBefore(hm, s);
+})();
+</script>
+HTML;
 
 return [
 
@@ -37,6 +48,8 @@ return [
     'public_locale' => env('GEOFLOW_PUBLIC_LOCALE', 'zh_CN'),
     // 默认前台主题；后台未显式选择主题时使用
     'default_theme' => env('GEOFLOW_DEFAULT_THEME', 'geoflow-template-21-enterprise-signature'),
+    // 仅在空库首次安装时写入；升级、重复安装和已有站点设置都不会覆盖。
+    'default_analytics_code' => $defaultAnalyticsCode,
     // 是否在手动 db:seed 中导入前台参考内容。geoflow:install 仅在全新空库默认导入。
     'seed_frontend_demo' => filter_var(env('GEOFLOW_SEED_FRONTEND_DEMO', false), FILTER_VALIDATE_BOOLEAN),
     // 参考内容默认只补缺，不覆盖用户已修改的作者、分类和文章；仅重置演示库时显式开启覆盖。

--- a/docs/readme/README_en.md
+++ b/docs/readme/README_en.md
@@ -237,7 +237,7 @@ php artisan key:generate
 
 GEOFLOW_SECURITY_FRESH_INSTALL_CONFIRMED=true php artisan migrate --force
 php artisan geoflow:install                                            # first install on an empty database
-# Optional minimal install: php artisan geoflow:install --without-demo
+# Skip the theme and reference articles while keeping first-install settings: php artisan geoflow:install --without-demo
 php artisan storage:link
 
 php artisan serve --host=127.0.0.1 --port=8080
@@ -281,7 +281,7 @@ chmod -R ug+rwx storage bootstrap/cache
 | Username | `GEOFLOW_ADMIN_USERNAME`, default `admin` |
 | Password | Local/dev default `password`; in production set `GEOFLOW_ADMIN_PASSWORD`. If it is empty and the account does not exist yet, the installer generates a one-time random password in the init / `geoflow:install` logs. |
 
-`geoflow:install` adds the default Enterprise Signature theme and the 50-article reference pack only on a fresh empty database. Use `--without-demo` for an admin-only minimal install. If the command detects existing user/business data, it records the installation marker and retains the current theme, settings, categories, authors, and articles. `AdminUserSeeder` remains idempotent and never overwrites an existing username, email, or password.
+On a fresh empty database, `geoflow:install` adds the default Enterprise Signature theme, the 50-article reference pack, and example Baidu Analytics code. `--without-demo` skips the theme and reference articles while retaining the administrator and example analytics code. The example immediately loads a script from `hm.baidu.com` and sends public-site visit data to the example Baidu Analytics account; before production launch, replace it under Site Settings → Analytics Code with your own code, or clear it to disable analytics. When existing user or business data is detected, the command records the installation marker and preserves the current theme, settings, categories, authors, articles, and analytics code. `AdminUserSeeder` remains idempotent and never overwrites an existing username, email, or password.
 
 ### Admin login lockout and manual unlock
 

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -3450,7 +3450,7 @@ return [
         'seo_title_help' => 'Available variables: {title}, {site_name}, {category}',
         'seo_description_help' => 'Available variables: {description}, {site_name}, {keywords}',
         'section_analytics' => 'Analytics',
-        'analytics_help' => 'This snippet is injected into the page <head> tag',
+        'analytics_help' => 'This snippet is injected into the page <head> tag. This is example code; replace it with your own analytics code',
         'analytics_super_admin_only' => 'Analytics code is injected directly into public pages. Only super admins can edit it.',
         'save_settings' => 'Save Settings',
         'error' => [

--- a/lang/pt_BR/admin.php
+++ b/lang/pt_BR/admin.php
@@ -1436,7 +1436,7 @@ return array_replace_recursive($base, [
         'seo_title_help' => 'Variáveis disponíveis: {title}, {site_name}, {category}',
         'seo_description_help' => 'Variáveis disponíveis: {description}, {site_name}, {keywords}',
         'section_analytics' => 'Analítica',
-        'analytics_help' => 'Este trecho é injetado na tag <head> da página',
+        'analytics_help' => 'Este trecho é inserido na tag <head> da página. Este é um código de exemplo; substitua-o pelo seu próprio código de análise',
         'analytics_super_admin_only' => 'O código de analítica é injetado diretamente nas páginas públicas. Apenas super-administradores podem editá-lo.',
         'save_settings' => 'Salvar Configurações',
         'error' => [

--- a/lang/zh_CN/admin.php
+++ b/lang/zh_CN/admin.php
@@ -3462,7 +3462,7 @@ return [
         'seo_title_help' => '可用变量: {title}, {site_name}, {category}',
         'seo_description_help' => '可用变量: {description}, {site_name}, {keywords}',
         'section_analytics' => '统计分析',
-        'analytics_help' => '将会插入到页面 <head> 标签中',
+        'analytics_help' => '将会插入到页面 <head> 标签中，此处为示例代码，请改成你的统计代码',
         'analytics_super_admin_only' => '统计代码会直接插入前台页面，只有超级管理员可以修改。',
         'save_settings' => '保存设置',
         'error' => [

--- a/tests/Feature/AdminSiteSettingsPageTest.php
+++ b/tests/Feature/AdminSiteSettingsPageTest.php
@@ -23,6 +23,29 @@ class AdminSiteSettingsPageTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_super_admin_sees_analytics_example_notice(): void
+    {
+        SiteSetting::query()->create([
+            'setting_key' => 'analytics_code',
+            'setting_value' => (string) config('geoflow.default_analytics_code'),
+        ]);
+
+        $admin = Admin::query()->create([
+            'username' => 'site_analytics_super_admin',
+            'password' => 'secret-123',
+            'email' => 'site-analytics-super-admin@example.com',
+            'display_name' => 'Site Analytics Super Admin',
+            'role' => 'super_admin',
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->get(route('admin.site-settings.index'))
+            ->assertOk()
+            ->assertSee('将会插入到页面 <head> 标签中，此处为示例代码，请改成你的统计代码')
+            ->assertSee((string) config('geoflow.default_analytics_code'));
+    }
+
     public function test_authenticated_admin_can_view_admin_base_path_setting(): void
     {
         $admin = Admin::query()->create([

--- a/tests/Feature/GeoFlowInstallCommandTest.php
+++ b/tests/Feature/GeoFlowInstallCommandTest.php
@@ -21,6 +21,18 @@ class GeoFlowInstallCommandTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const BAIDU_ANALYTICS_EXAMPLE = <<<'HTML'
+<script>
+var _hmt = _hmt || [];
+(function() {
+  var hm = document.createElement("script");
+  hm.src = "https://hm.baidu.com/hm.js?1743638f313788caa4cb55e299444a87";
+  var s = document.getElementsByTagName("script")[0];
+  s.parentNode.insertBefore(hm, s);
+})();
+</script>
+HTML;
+
     public function test_install_command_seeds_empty_database_once_and_writes_marker(): void
     {
         Config::set('geoflow.seed_frontend_demo', false);
@@ -41,6 +53,17 @@ class GeoFlowInstallCommandTest extends TestCase
             'geoflow-template-21-enterprise-signature',
             SiteSetting::query()->where('setting_key', 'active_theme')->value('setting_value'),
         );
+        $this->assertSame(
+            self::BAIDU_ANALYTICS_EXAMPLE,
+            SiteSetting::query()->where('setting_key', 'analytics_code')->value('setting_value'),
+        );
+        $response = $this->get(route('site.home'))
+            ->assertOk()
+            ->assertSee('https://hm.baidu.com/hm.js?1743638f313788caa4cb55e299444a87', false);
+        $this->assertSame(
+            1,
+            substr_count($response->getContent(), 'https://hm.baidu.com/hm.js?1743638f313788caa4cb55e299444a87'),
+        );
 
         $state = SystemState::query()->where('key', GeoFlowInstallCommand::INSTALLATION_STATE_KEY)->first();
         $this->assertNotNull($state);
@@ -58,6 +81,10 @@ class GeoFlowInstallCommandTest extends TestCase
             'password' => 'custom-secret',
         ])->save();
         $originalPasswordHash = (string) $admin->password;
+        SiteSetting::query()->updateOrCreate(
+            ['setting_key' => 'analytics_code'],
+            ['setting_value' => '<script>userAnalytics()</script>'],
+        );
 
         $this->artisan('geoflow:install')
             ->assertExitCode(0);
@@ -66,6 +93,10 @@ class GeoFlowInstallCommandTest extends TestCase
         $this->assertSame('custom-admin@example.com', $admin->email);
         $this->assertSame($originalPasswordHash, (string) $admin->password);
         $this->assertSame(1, Admin::query()->where('username', 'admin')->count());
+        $this->assertSame(
+            '<script>userAnalytics()</script>',
+            SiteSetting::query()->where('setting_key', 'analytics_code')->value('setting_value'),
+        );
     }
 
     public function test_install_command_backfills_marker_for_existing_database_without_seeding(): void
@@ -77,6 +108,10 @@ class GeoFlowInstallCommandTest extends TestCase
         SiteSetting::query()->where('setting_key', 'active_theme')->update([
             'setting_value' => 'user-owned-theme',
         ]);
+        SiteSetting::query()->create([
+            'setting_key' => 'analytics_code',
+            'setting_value' => '<script>existingAnalytics()</script>',
+        ]);
 
         $this->artisan('geoflow:install')
             ->assertExitCode(0);
@@ -85,6 +120,10 @@ class GeoFlowInstallCommandTest extends TestCase
         $this->assertSame(0, Category::query()->count());
         $this->assertSame('用户线上站点', SiteSetting::query()->where('setting_key', 'site_name')->value('setting_value'));
         $this->assertSame('user-owned-theme', SiteSetting::query()->where('setting_key', 'active_theme')->value('setting_value'));
+        $this->assertSame(
+            '<script>existingAnalytics()</script>',
+            SiteSetting::query()->where('setting_key', 'analytics_code')->value('setting_value'),
+        );
 
         $state = SystemState::query()->where('key', GeoFlowInstallCommand::INSTALLATION_STATE_KEY)->first();
         $this->assertNotNull($state);
@@ -152,6 +191,7 @@ class GeoFlowInstallCommandTest extends TestCase
         $this->assertSame(0, Admin::query()->count());
         $this->assertSame(0, Category::query()->count());
         $this->assertSame(0, Article::query()->count());
+        $this->assertFalse(SiteSetting::query()->where('setting_key', 'analytics_code')->exists());
         $this->assertFalse(SystemState::query()->where('key', GeoFlowInstallCommand::INSTALLATION_STATE_KEY)->exists());
 
         $this->app->bind(FrontendReferenceSeeder::class, fn () => new FrontendReferenceSeeder);
@@ -183,6 +223,10 @@ class GeoFlowInstallCommandTest extends TestCase
             'geoflow-template-21-enterprise-signature',
             SiteSetting::query()->where('setting_key', 'active_theme')->value('setting_value'),
         );
+        $this->assertSame(
+            self::BAIDU_ANALYTICS_EXAMPLE,
+            SiteSetting::query()->where('setting_key', 'analytics_code')->value('setting_value'),
+        );
 
         $state = SystemState::query()->where('key', GeoFlowInstallCommand::INSTALLATION_STATE_KEY)->firstOrFail();
         $this->assertFalse($state->value['seed_frontend_reference'] ?? true);
@@ -197,12 +241,20 @@ class GeoFlowInstallCommandTest extends TestCase
             'setting_key' => 'site_name',
             'setting_value' => '已部署站点',
         ]);
+        SiteSetting::query()->create([
+            'setting_key' => 'analytics_code',
+            'setting_value' => '<script>existingAnalytics()</script>',
+        ]);
 
         $this->artisan('geoflow:install', ['--force' => true])->assertSuccessful();
 
         $this->assertSame(0, Article::query()->count());
         $this->assertSame(0, Category::query()->count());
         $this->assertSame('user-owned-theme', SiteSetting::query()->where('setting_key', 'active_theme')->value('setting_value'));
+        $this->assertSame(
+            '<script>existingAnalytics()</script>',
+            SiteSetting::query()->where('setting_key', 'analytics_code')->value('setting_value'),
+        );
     }
 
     public function test_install_command_reports_installation_and_later_version_change(): void


### PR DESCRIPTION
## 变更

- 全新空库首次安装时写入指定的百度统计示例代码
- 后台统计代码帮助文案提示部署者替换示例
- --without-demo 仍保留管理员和首次安装基础设置
- 重复安装、已有站点升级及 --force 均保留站点当前统计代码
- 中英文部署文档明确说明脚本会加载 hm.baidu.com，并提示上线前替换或清空

## 验证

- composer test：退出码 0，9955 assertions
- 首装、站点设置和文案规范定向测试：退出码 0，726 assertions
- npm run build：通过
- 独立 SQLite 空库完成迁移与真实安装；首次写入示例代码，普通重跑和 --force 均保留自定义代码
- PHP 语法、Pint、配置缓存和 diff 检查通过
- 安全专项复核：0 个 HIGH finding；第三方统计与地区隐私合规作为部署提示保留

## 数据边界

该默认值只进入全新空库首次安装路径，不通过迁移、升级补写、配置回退或演示内容 Seeder 注入。已有部署的统计代码不会被新增或覆盖。