### PR TITLE
fix: avoid repeated storage permission scans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ GEOFLOW_PUBLIC_LOCALE=zh_CN
 
 # 开发 Docker 入口（docker/entrypoint.sh）：迁移完成后是否执行 php artisan optimize（默认 false；生产见 .env.prod.example / entrypoint.prod.sh）
 AUTO_OPTIMIZE=false
-# Docker 入口启动时自动修正 storage/bootstrap/cache 权限，适配宿主机 bind mount。
+# Docker init 服务启动时修正 storage/bootstrap/cache 权限；常驻服务已关闭重复扫描。
 AUTO_FIX_STORAGE_PERMISSIONS=true
 GEOFLOW_ITEMS_PER_PAGE=12
 GEOFLOW_ADMIN_ITEMS_PER_PAGE=20

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -24,7 +24,7 @@ GEOFLOW_PUBLIC_LOCALE=zh_CN
 
 # Docker 入口：迁移完成后是否执行 php artisan optimize（默认 true）
 AUTO_OPTIMIZE=true
-# Docker 入口启动时自动修正 storage/bootstrap/cache 权限，适配宿主机 bind mount。
+# Docker init 服务启动时修正 storage/bootstrap/cache 权限；常驻服务已关闭重复扫描。
 AUTO_FIX_STORAGE_PERMISSIONS=true
 GEOFLOW_ITEMS_PER_PAGE=12
 GEOFLOW_ADMIN_ITEMS_PER_PAGE=20

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -49,7 +49,9 @@ services:
     working_dir: /var/www/html
     env_file:
       - ./.env.prod
-    command: ["php", "artisan", "about"]
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "${AUTO_FIX_STORAGE_PERMISSIONS:-true}"
+    command: ["true"]
     volumes:
       - ./.env.prod:/var/www/html/.env
       - ./storage:/var/www/html/storage
@@ -65,6 +67,9 @@ services:
     container_name: geoflow-app-prod
     mem_limit: ${APP_CONTAINER_MEMORY_LIMIT:-768m}
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     volumes:
       - ./.env.prod:/var/www/html/.env
       - ./storage:/var/www/html/storage
@@ -101,6 +106,9 @@ services:
     image: ${GEOFLOW_APP_IMAGE:?GEOFLOW_APP_IMAGE is required for prebuilt deployment}
     container_name: geoflow-queue-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "-d", "memory_limit=256M", "artisan", "queue:work", "redis", "--queue=geoflow,distribution,theme-replication,default", "--sleep=1", "--tries=1", "--timeout=660", "--memory=128", "--max-jobs=100", "--max-time=3600"]
     mem_limit: ${QUEUE_CONTAINER_MEMORY_LIMIT:-384m}
     stop_grace_period: 690s
@@ -118,6 +126,9 @@ services:
     image: ${GEOFLOW_APP_IMAGE:?GEOFLOW_APP_IMAGE is required for prebuilt deployment}
     container_name: geoflow-knowledge-queue-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "-d", "memory_limit=160M", "artisan", "queue:work", "redis", "--queue=knowledge", "--sleep=1", "--tries=1", "--timeout=210", "--memory=128", "--max-jobs=20", "--max-time=1800"]
     mem_limit: ${KNOWLEDGE_QUEUE_CONTAINER_MEMORY_LIMIT:-256m}
     stop_grace_period: 240s
@@ -135,6 +146,9 @@ services:
     image: ${GEOFLOW_APP_IMAGE:?GEOFLOW_APP_IMAGE is required for prebuilt deployment}
     container_name: geoflow-system-update-queue-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "-d", "memory_limit=256M", "artisan", "queue:work", "redis", "--queue=system-updates", "--sleep=1", "--tries=1", "--timeout=930", "--memory=256", "--max-jobs=10", "--max-time=3600"]
     mem_limit: ${SYSTEM_UPDATE_QUEUE_CONTAINER_MEMORY_LIMIT:-384m}
     stop_grace_period: 960s
@@ -152,6 +166,9 @@ services:
     image: ${GEOFLOW_APP_IMAGE:?GEOFLOW_APP_IMAGE is required for prebuilt deployment}
     container_name: geoflow-scheduler-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "artisan", "schedule:work"]
     volumes:
       - ./.env.prod:/var/www/html/.env
@@ -165,6 +182,9 @@ services:
     image: ${GEOFLOW_APP_IMAGE:?GEOFLOW_APP_IMAGE is required for prebuilt deployment}
     container_name: geoflow-reverb-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     # 端口由 .env.prod 的 REVERB_SERVER_PORT 决定（见 config/reverb.php）；nginx /reverb 反代端口须与之对齐
     command: ["php", "artisan", "reverb:start", "--host=0.0.0.0"]
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,8 +63,9 @@ services:
     env_file:
       - ./.env.prod
     environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "${AUTO_FIX_STORAGE_PERMISSIONS:-true}"
       GEOFLOW_SECURITY_FRESH_INSTALL_CONFIRMED: "true"
-    command: ["php", "artisan", "about"]
+    command: ["true"]
     volumes:
       - ./.env.prod:/var/www/html/.env
       - ./storage:/var/www/html/storage
@@ -85,6 +86,9 @@ services:
     container_name: geoflow-app-prod
     mem_limit: ${APP_CONTAINER_MEMORY_LIMIT:-768m}
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     volumes:
       - ./.env.prod:/var/www/html/.env
       - ./storage:/var/www/html/storage
@@ -132,6 +136,9 @@ services:
       args: *prod_app_build_args
     container_name: geoflow-queue-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "-d", "memory_limit=256M", "artisan", "queue:work", "redis", "--queue=geoflow,distribution,theme-replication,default", "--sleep=1", "--tries=1", "--timeout=660", "--memory=128", "--max-jobs=100", "--max-time=3600"]
     mem_limit: ${QUEUE_CONTAINER_MEMORY_LIMIT:-384m}
     stop_grace_period: 690s
@@ -154,6 +161,9 @@ services:
       args: *prod_app_build_args
     container_name: geoflow-knowledge-queue-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "-d", "memory_limit=160M", "artisan", "queue:work", "redis", "--queue=knowledge", "--sleep=1", "--tries=1", "--timeout=210", "--memory=128", "--max-jobs=20", "--max-time=1800"]
     mem_limit: ${KNOWLEDGE_QUEUE_CONTAINER_MEMORY_LIMIT:-256m}
     stop_grace_period: 240s
@@ -176,6 +186,9 @@ services:
       args: *prod_app_build_args
     container_name: geoflow-system-update-queue-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "-d", "memory_limit=256M", "artisan", "queue:work", "redis", "--queue=system-updates", "--sleep=1", "--tries=1", "--timeout=930", "--memory=256", "--max-jobs=10", "--max-time=3600"]
     mem_limit: ${SYSTEM_UPDATE_QUEUE_CONTAINER_MEMORY_LIMIT:-384m}
     stop_grace_period: 960s
@@ -198,6 +211,9 @@ services:
       args: *prod_app_build_args
     container_name: geoflow-scheduler-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     command: ["php", "artisan", "schedule:work"]
     volumes:
       - ./.env.prod:/var/www/html/.env
@@ -216,6 +232,9 @@ services:
       args: *prod_app_build_args
     container_name: geoflow-reverb-prod
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
+    user: "www-data:www-data"
     # 端口由 .env.prod 的 REVERB_SERVER_PORT 决定（见 config/reverb.php）；nginx /reverb 反代端口须与之对齐
     command: ["php", "artisan", "reverb:start", "--host=0.0.0.0"]
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,10 @@ services:
     env_file:
       - ./.env
     environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "${AUTO_FIX_STORAGE_PERMISSIONS:-true}"
       GEOFLOW_SECURITY_FRESH_INSTALL_CONFIRMED: "true"
     # 交给 entrypoint 执行自动初始化（生成 APP_KEY / migrate / geoflow:install）
-    command: ["php", "artisan", "about"]
+    command: ["true"]
     volumes:
       - ./:/var/www/html
     depends_on:
@@ -71,6 +72,8 @@ services:
         COMPOSER_PACKAGIST_MIRROR: ${COMPOSER_PACKAGIST_MIRROR:-}
     container_name: geoflow-app
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
     command: ["php", "artisan", "serve", "--host=0.0.0.0", "--port=8080"]
     ports:
       - "${APP_PORT:-18080}:8080"
@@ -93,6 +96,8 @@ services:
         COMPOSER_PACKAGIST_MIRROR: ${COMPOSER_PACKAGIST_MIRROR:-}
     container_name: geoflow-queue
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
     command: ["php", "-d", "memory_limit=256M", "artisan", "queue:work", "redis", "--queue=geoflow,distribution,theme-replication,default", "--sleep=1", "--tries=1", "--timeout=660", "--memory=128", "--max-jobs=100", "--max-time=3600"]
     mem_limit: ${QUEUE_CONTAINER_MEMORY_LIMIT:-384m}
     stop_grace_period: 690s
@@ -113,6 +118,8 @@ services:
         COMPOSER_PACKAGIST_MIRROR: ${COMPOSER_PACKAGIST_MIRROR:-}
     container_name: geoflow-knowledge-queue
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
     command: ["php", "-d", "memory_limit=160M", "artisan", "queue:work", "redis", "--queue=knowledge", "--sleep=1", "--tries=1", "--timeout=210", "--memory=128", "--max-jobs=20", "--max-time=1800"]
     mem_limit: ${KNOWLEDGE_QUEUE_CONTAINER_MEMORY_LIMIT:-256m}
     stop_grace_period: 240s
@@ -133,6 +140,8 @@ services:
         COMPOSER_PACKAGIST_MIRROR: ${COMPOSER_PACKAGIST_MIRROR:-}
     container_name: geoflow-system-update-queue
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
     command: ["php", "-d", "memory_limit=256M", "artisan", "queue:work", "redis", "--queue=system-updates", "--sleep=1", "--tries=1", "--timeout=930", "--memory=256", "--max-jobs=10", "--max-time=3600"]
     mem_limit: ${SYSTEM_UPDATE_QUEUE_CONTAINER_MEMORY_LIMIT:-384m}
     stop_grace_period: 960s
@@ -153,6 +162,8 @@ services:
         COMPOSER_PACKAGIST_MIRROR: ${COMPOSER_PACKAGIST_MIRROR:-}
     container_name: geoflow-scheduler
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
     command: ["php", "artisan", "schedule:work"]
     volumes:
       - ./:/var/www/html
@@ -171,6 +182,8 @@ services:
         COMPOSER_PACKAGIST_MIRROR: ${COMPOSER_PACKAGIST_MIRROR:-}
     container_name: geoflow-reverb
     working_dir: /var/www/html
+    environment:
+      AUTO_FIX_STORAGE_PERMISSIONS: "false"
     command: ["php", "artisan", "reverb:start", "--host=0.0.0.0", "--port=8080"]
     ports:
       - "${REVERB_EXPOSE_PORT:-18081}:8080"

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -125,5 +125,10 @@ RUN chmod +x /usr/local/bin/geoflow-entrypoint-prod
 COPY --from=vendor /app /var/www/html
 COPY --from=assets /app/public/build /var/www/html/public/build
 
+# Runtime services run as www-data and skip recursive permission repair.
+RUN rm -f public/storage \
+    && ln -s ../storage/app/public public/storage \
+    && chown -R www-data:www-data storage bootstrap/cache
+
 ENTRYPOINT ["/usr/local/bin/geoflow-entrypoint-prod"]
 CMD ["php-fpm", "-F"]

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -30,20 +30,6 @@ mkdir -p \
   storage/framework/views \
   storage/logs
 
-if [ "${AUTO_FIX_STORAGE_PERMISSIONS:-true}" = "true" ]; then
-  if [ "$(id -u)" = "0" ]; then
-    RUNTIME_USER="${RUNTIME_USER:-www-data}"
-    RUNTIME_GROUP="${RUNTIME_GROUP:-www-data}"
-
-    echo "[entrypoint-prod] fixing storage permissions for ${RUNTIME_USER}:${RUNTIME_GROUP}"
-    chown -R "${RUNTIME_USER}:${RUNTIME_GROUP}" storage bootstrap/cache
-    find storage bootstrap/cache -type d -exec chmod 775 {} \;
-    find storage bootstrap/cache -type f -exec chmod 664 {} \;
-  else
-    echo "[entrypoint-prod] skip permission fix: container is not running as root"
-  fi
-fi
-
 if [ ! -e public/storage ]; then
   php artisan storage:link --force --no-interaction
 fi
@@ -77,6 +63,20 @@ fi
 if [ "${AUTO_OPTIMIZE:-true}" = "true" ]; then
   echo "[entrypoint-prod] php artisan optimize"
   php artisan optimize --no-interaction
+fi
+
+if [ "${AUTO_FIX_STORAGE_PERMISSIONS:-true}" = "true" ]; then
+  if [ "$(id -u)" = "0" ]; then
+    RUNTIME_USER="${RUNTIME_USER:-www-data}"
+    RUNTIME_GROUP="${RUNTIME_GROUP:-www-data}"
+
+    echo "[entrypoint-prod] fixing storage permissions for ${RUNTIME_USER}:${RUNTIME_GROUP}"
+    chown -R "${RUNTIME_USER}:${RUNTIME_GROUP}" storage bootstrap/cache
+    find storage bootstrap/cache -type d -exec chmod 775 {} +
+    find storage bootstrap/cache -type f -exec chmod 664 {} +
+  else
+    echo "[entrypoint-prod] skip permission fix: container is not running as root"
+  fi
 fi
 
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -61,20 +61,6 @@ mkdir -p \
   storage/framework/views \
   storage/logs
 
-if [ "${AUTO_FIX_STORAGE_PERMISSIONS:-true}" = "true" ]; then
-  if [ "$(id -u)" = "0" ]; then
-    RUNTIME_USER="${RUNTIME_USER:-www-data}"
-    RUNTIME_GROUP="${RUNTIME_GROUP:-www-data}"
-
-    echo "[entrypoint] fixing storage permissions for ${RUNTIME_USER}:${RUNTIME_GROUP}"
-    chown -R "${RUNTIME_USER}:${RUNTIME_GROUP}" storage bootstrap/cache
-    find storage bootstrap/cache -type d -exec chmod 775 {} \;
-    find storage bootstrap/cache -type f -exec chmod 664 {} \;
-  else
-    echo "[entrypoint] skip permission fix: container is not running as root"
-  fi
-fi
-
 if [ ! -e public/storage ]; then
   php artisan storage:link --force --no-interaction
 fi
@@ -123,6 +109,20 @@ if [ "${AUTO_OPTIMIZE:-false}" = "true" ]; then
     php artisan optimize --no-interaction || echo "[entrypoint] warning: php artisan optimize failed, continuing"
   else
     echo "[entrypoint] skip php artisan optimize (no valid APP_KEY in .env)"
+  fi
+fi
+
+if [ "${AUTO_FIX_STORAGE_PERMISSIONS:-true}" = "true" ]; then
+  if [ "$(id -u)" = "0" ]; then
+    RUNTIME_USER="${RUNTIME_USER:-www-data}"
+    RUNTIME_GROUP="${RUNTIME_GROUP:-www-data}"
+
+    echo "[entrypoint] fixing storage permissions for ${RUNTIME_USER}:${RUNTIME_GROUP}"
+    chown -R "${RUNTIME_USER}:${RUNTIME_GROUP}" storage bootstrap/cache
+    find storage bootstrap/cache -type d -exec chmod 775 {} +
+    find storage bootstrap/cache -type f -exec chmod 664 {} +
+  else
+    echo "[entrypoint] skip permission fix: container is not running as root"
   fi
 fi
 

--- a/tests/Unit/DockerStoragePermissionsConfigurationTest.php
+++ b/tests/Unit/DockerStoragePermissionsConfigurationTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class DockerStoragePermissionsConfigurationTest extends TestCase
+{
+    public function test_entrypoints_batch_storage_permission_changes(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        foreach (['docker/entrypoint.sh', 'docker/entrypoint.prod.sh'] as $entrypointFile) {
+            $entrypoint = file_get_contents($root.'/'.$entrypointFile);
+
+            $this->assertIsString($entrypoint);
+            $this->assertStringContainsString(
+                'find storage bootstrap/cache -type d -exec chmod 775 {} +',
+                $entrypoint,
+                $entrypointFile.' must batch directory permission changes.'
+            );
+            $this->assertStringContainsString(
+                'find storage bootstrap/cache -type f -exec chmod 664 {} +',
+                $entrypoint,
+                $entrypointFile.' must batch file permission changes.'
+            );
+            $this->assertStringNotContainsString(
+                '-exec chmod 775 {} \;',
+                $entrypoint,
+                $entrypointFile.' must not spawn chmod once per directory.'
+            );
+            $this->assertStringNotContainsString(
+                '-exec chmod 664 {} \;',
+                $entrypoint,
+                $entrypointFile.' must not spawn chmod once per file.'
+            );
+            $optimizePosition = strpos($entrypoint, 'if [ "${AUTO_OPTIMIZE:');
+            $permissionPosition = strpos($entrypoint, 'if [ "${AUTO_FIX_STORAGE_PERMISSIONS:');
+            $this->assertNotFalse($optimizePosition);
+            $this->assertNotFalse($permissionPosition);
+            $this->assertGreaterThan(
+                $optimizePosition,
+                $permissionPosition,
+                $entrypointFile.' must repair permissions after initialization writes finish.'
+            );
+        }
+    }
+
+    public function test_only_init_can_automatically_fix_storage_permissions(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        foreach (['docker-compose.yml', 'docker-compose.prod.yml', 'docker-compose.prebuilt.yml'] as $composeFile) {
+            $compose = file_get_contents($root.'/'.$composeFile);
+
+            $this->assertIsString($compose);
+            $services = $this->serviceBlocks($compose);
+            $this->assertArrayHasKey('init', $services, $composeFile.' must define the init service.');
+            $this->assertStringContainsString(
+                'AUTO_FIX_STORAGE_PERMISSIONS: "${AUTO_FIX_STORAGE_PERMISSIONS:-true}"',
+                $services['init'],
+                $composeFile.' must let the operator control the one-shot storage repair.'
+            );
+            $this->assertStringContainsString(
+                'command: ["true"]',
+                $services['init'],
+                $composeFile.' must not run another Artisan command after the final permission repair.'
+            );
+
+            $runtimeServices = array_filter(
+                $services,
+                fn (string $block, string $service): bool => $service !== 'init'
+                    && $this->usesApplicationImage($block),
+                ARRAY_FILTER_USE_BOTH
+            );
+            $this->assertNotEmpty($runtimeServices, $composeFile.' must define application runtime services.');
+
+            foreach ($runtimeServices as $service => $block) {
+                $this->assertStringContainsString(
+                    'AUTO_FIX_STORAGE_PERMISSIONS: "false"',
+                    $block,
+                    sprintf('%s must disable repeated permission repair in %s.', $composeFile, $service)
+                );
+                $this->assertStringContainsString(
+                    "      init:\n        condition: service_completed_successfully",
+                    $block,
+                    sprintf('%s must wait for init before starting %s.', $composeFile, $service)
+                );
+            }
+
+            $this->assertSame(
+                1,
+                substr_count($compose, 'AUTO_FIX_STORAGE_PERMISSIONS: "${AUTO_FIX_STORAGE_PERMISSIONS:-true}"')
+            );
+            $this->assertSame(count($runtimeServices), substr_count($compose, 'AUTO_FIX_STORAGE_PERMISSIONS: "false"'));
+        }
+    }
+
+    public function test_production_image_prepares_container_local_cache_permissions(): void
+    {
+        $dockerfile = file_get_contents(dirname(__DIR__, 2).'/docker/Dockerfile.prod');
+
+        $this->assertIsString($dockerfile);
+        $this->assertStringContainsString(
+            'chown -R www-data:www-data storage bootstrap/cache',
+            $dockerfile,
+            'The production image must make its private bootstrap/cache writable before runtime scans are disabled.'
+        );
+        $this->assertStringContainsString(
+            'ln -s ../storage/app/public public/storage',
+            $dockerfile,
+            'The production image must prepare the storage link before runtime services drop root privileges.'
+        );
+        $this->assertStringContainsString(
+            'rm -f public/storage',
+            $dockerfile,
+            'The production image must replace an existing development storage link safely.'
+        );
+    }
+
+    public function test_production_runtime_services_use_the_shared_storage_owner(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        foreach (['docker-compose.prod.yml', 'docker-compose.prebuilt.yml'] as $composeFile) {
+            $compose = file_get_contents($root.'/'.$composeFile);
+            $this->assertIsString($compose);
+
+            $services = $this->serviceBlocks($compose);
+            $runtimeServices = array_filter(
+                $services,
+                fn (string $block, string $service): bool => $service !== 'init'
+                    && $this->usesApplicationImage($block),
+                ARRAY_FILTER_USE_BOTH
+            );
+
+            $this->assertStringNotContainsString('user:', $services['init']);
+
+            foreach ($runtimeServices as $service => $block) {
+                $this->assertStringContainsString(
+                    'user: "www-data:www-data"',
+                    $block,
+                    sprintf('%s must run %s as the shared storage owner.', $composeFile, $service)
+                );
+            }
+        }
+    }
+
+    public function test_compose_renders_the_operator_storage_permission_override_when_available(): void
+    {
+        $docker = new Process(['docker', 'compose', 'version']);
+        $docker->run();
+
+        if (! $docker->isSuccessful()) {
+            $this->markTestSkipped('Docker Compose is required to verify rendered deployment configuration.');
+        }
+
+        $root = dirname(__DIR__, 2);
+        foreach (['docker-compose.yml', 'docker-compose.prod.yml', 'docker-compose.prebuilt.yml'] as $composeFile) {
+            $compose = file_get_contents($root.'/'.$composeFile);
+            $this->assertIsString($compose);
+
+            $runtimeServices = array_filter(
+                $this->serviceBlocks($compose),
+                fn (string $block, string $service): bool => $service !== 'init'
+                    && $this->usesApplicationImage($block),
+                ARRAY_FILTER_USE_BOTH
+            );
+
+            foreach ([
+                ['value' => false, 'expected' => 'true'],
+                ['value' => 'false', 'expected' => 'false'],
+            ] as $scenario) {
+                $rendered = $this->renderCompose(
+                    $root,
+                    $composeFile,
+                    ['AUTO_FIX_STORAGE_PERMISSIONS' => $scenario['value']]
+                );
+
+                $this->assertSame(
+                    $scenario['expected'],
+                    $rendered['services']['init']['environment']['AUTO_FIX_STORAGE_PERMISSIONS'] ?? null,
+                    $composeFile.' must preserve the operator storage permission setting for init.'
+                );
+
+                foreach (array_keys($runtimeServices) as $service) {
+                    $this->assertSame(
+                        'false',
+                        $rendered['services'][$service]['environment']['AUTO_FIX_STORAGE_PERMISSIONS'] ?? null,
+                        sprintf('%s must keep repeated permission repair disabled in %s.', $composeFile, $service)
+                    );
+                }
+            }
+        }
+    }
+
+    /** @return array<string, string> */
+    private function serviceBlocks(string $compose): array
+    {
+        preg_match_all(
+            '/^  (?<name>[a-zA-Z0-9_-]+):\R(?<block>(?:(?!^  [a-zA-Z0-9_-]+:\R).)*)/ms',
+            $compose,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        $services = [];
+        foreach ($matches as $match) {
+            $services[(string) $match['name']] = (string) $match['block'];
+        }
+
+        return $services;
+    }
+
+    private function usesApplicationImage(string $serviceBlock): bool
+    {
+        return str_contains($serviceBlock, 'image: geoflow-app')
+            || str_contains($serviceBlock, 'image: ${GEOFLOW_APP_IMAGE');
+    }
+
+    /**
+     * @param  array<string, string|false>  $environment
+     * @return array<string, mixed>
+     */
+    private function renderCompose(string $root, string $composeFile, array $environment): array
+    {
+        $emptyEnvFile = tempnam(sys_get_temp_dir(), 'geoflow-compose-env-');
+        $this->assertNotFalse($emptyEnvFile);
+
+        $process = new Process(
+            [
+                'docker',
+                'compose',
+                '--env-file',
+                $emptyEnvFile,
+                '-f',
+                $composeFile,
+                'config',
+                '--no-env-resolution',
+                '--format',
+                'json',
+            ],
+            $root,
+            array_merge(
+                [
+                    'GEOFLOW_APP_IMAGE' => 'geoflow-app:test',
+                    'GEOFLOW_WEB_IMAGE' => 'geoflow-web:test',
+                ],
+                $environment
+            )
+        );
+
+        try {
+            $process->run();
+        } finally {
+            unlink($emptyEnvFile);
+        }
+
+        $this->assertTrue($process->isSuccessful(), trim($process->getErrorOutput()));
+
+        return json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary

- batch `chmod` operations and run recursive ownership repair once in `init`
- keep production runtime services on the shared `www-data` owner
- preserve the operator opt-out and prepare production image cache/storage paths
- add regression coverage for Compose rendering, init ordering, service dependencies, and image permissions

## Root cause

Every application container recursively scanned `storage` on startup. Moving repair to `init` also exposed an ownership hazard because init and CLI workers ran as root while PHP-FPM workers used `www-data`.

## Validation

- focused Docker storage and queue configuration tests: 17 passed, 249 assertions
- full Laravel test suite: 164 passed, 10,770 assertions
- Docker Compose configuration validation for development, production, and prebuilt variants
- production image build with an existing `public/storage` link
- production runtime smoke test as `www-data`, including optimize and PHP-FPM startup
