### PR TITLE
feat(ai): register OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,12 +22,15 @@ use App\View\Composers\SiteLayoutComposer;
 use Closure;
 use GuzzleHttp\Utils;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\OpenAiCompatibleProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -69,6 +72,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // OrcaRouter 是 OpenAI 兼容网关，注册为命名驱动（同 openrouter/deepseek 具名先例）。
+        Ai::extend('orcarouter', fn ($app, array $config) => new OpenAiCompatibleProvider($config, $app->make(Dispatcher::class)));
+
         RateLimiter::for('admin-login', function (Request $request): Limit {
             return Limit::perMinute(30)->by('admin-login-ip:'.$request->ip());
         });

--- a/app/Support/GeoFlow/OpenAiRuntimeProvider.php
+++ b/app/Support/GeoFlow/OpenAiRuntimeProvider.php
@@ -99,6 +99,10 @@ final class OpenAiRuntimeProvider
             return 'deepseek';
         }
 
+        if (self::isOrcaRouterProviderUrl($normalized)) {
+            return 'orcarouter';
+        }
+
         return 'openai-compatible';
     }
 
@@ -109,6 +113,10 @@ final class OpenAiRuntimeProvider
     {
         if (self::isGeminiProviderUrl($apiUrl)) {
             return 'gemini';
+        }
+
+        if (self::isOrcaRouterProviderUrl($apiUrl)) {
+            return 'orcarouter';
         }
 
         $host = strtolower((string) (parse_url(trim($apiUrl), PHP_URL_HOST) ?? ''));
@@ -124,6 +132,16 @@ final class OpenAiRuntimeProvider
         $host = strtolower((string) (parse_url(trim($apiUrl), PHP_URL_HOST) ?? ''));
 
         return $host === 'generativelanguage.googleapis.com';
+    }
+
+    /**
+     * 判断 URL 是否指向 OrcaRouter 网关（OpenAI 兼容，驱动名为 orcarouter）。
+     */
+    public static function isOrcaRouterProviderUrl(string $apiUrl): bool
+    {
+        $host = strtolower((string) (parse_url(trim($apiUrl), PHP_URL_HOST) ?? ''));
+
+        return str_contains($host, 'orcarouter.ai');
     }
 
     /**

--- a/tests/Unit/OpenAiRuntimeProviderTest.php
+++ b/tests/Unit/OpenAiRuntimeProviderTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit;
 
 use App\Support\GeoFlow\OpenAiRuntimeProvider;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\OpenAiCompatibleProvider;
 use RuntimeException;
 use Tests\TestCase;
 use TypeError;
@@ -175,6 +177,32 @@ class OpenAiRuntimeProviderTest extends TestCase
     public function test_it_resolves_chat_driver_for_openrouter(): void
     {
         $this->assertSame('openrouter', OpenAiRuntimeProvider::resolveChatDriver('https://openrouter.ai/api/v1', 'anthropic/claude-3'));
+    }
+
+    public function test_it_resolves_chat_driver_for_orcarouter(): void
+    {
+        $this->assertSame('orcarouter', OpenAiRuntimeProvider::resolveChatDriver('https://api.orcarouter.ai/v1', 'orcarouter/auto'));
+        $this->assertSame('orcarouter', OpenAiRuntimeProvider::resolveChatDriver('https://api.orcarouter.ai', 'openai/gpt-4o'));
+        $this->assertTrue(OpenAiRuntimeProvider::isOrcaRouterProviderUrl('https://api.orcarouter.ai/v1'));
+    }
+
+    public function test_it_resolves_embedding_driver_for_orcarouter(): void
+    {
+        $this->assertSame('orcarouter', OpenAiRuntimeProvider::resolveEmbeddingDriver('https://api.orcarouter.ai/v1', 'openai/text-embedding-3-small'));
+    }
+
+    public function test_it_registers_and_resolves_the_orcarouter_runtime_driver(): void
+    {
+        $providerName = OpenAiRuntimeProvider::registerProvider(
+            'orcarouter_test',
+            'orcarouter',
+            'https://api.orcarouter.ai/v1',
+            'test-key',
+        );
+
+        $provider = Ai::textProvider($providerName);
+
+        $this->assertInstanceOf(OpenAiCompatibleProvider::class, $provider);
     }
 
     public function test_it_resolves_chat_driver_for_zhipu(): void


### PR DESCRIPTION
This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing OpenRouter provider is wired, so the model picker, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Changes

- `app/Support/GeoFlow/OpenAiRuntimeProvider.php` — `resolveChatDriver()` and `resolveEmbeddingDriver()` now return the `orcarouter` driver for `api.orcarouter.ai` hosts, sitting beside the existing `openrouter` / `deepseek` named-driver branches.
- `app/Providers/AppServiceProvider.php` — registers the `orcarouter` driver via `Ai::extend()`, backed by Laravel AI's `OpenAiCompatibleProvider` (same adapter OpenRouter uses).
- `tests/Unit/OpenAiRuntimeProviderTest.php` — adds coverage for chat/embedding driver resolution and runtime `registerProvider()` + `Ai::textProvider()` resolution.

## Verification

- `phpunit --filter OpenAiRuntimeProviderTest` → 25/25 pass (38 assertions).
- Full Unit suite: 449 tests, 2 errors + 13 failures — all reproduced on pristine `main` (baseline) and are pre-existing Windows-environment issues (symlink permission checks, `chmod`/0600 assertions, unavailable `curl_*` functions, git release-sync scripts). No new failures introduced.
- Live wire check: `GET /v1/models` (207 models, `orcarouter/auto` present) and `POST /v1/chat/completions` for `orcarouter/auto` and `anthropic/claude-sonnet-4.6` both return 200.
