### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,4 +445,4 @@ composer test
 
 ## ⭐ Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.com/#yaojingang/GEOFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.dera.page/#yaojingang/GEOFlow&Date)

--- a/docs/readme/README_en.md
+++ b/docs/readme/README_en.md
@@ -371,4 +371,4 @@ GEOFlow is licensed under the [Apache License 2.0](../../LICENSE). It allows per
 
 ## ⭐ Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.com/#yaojingang/GEOFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.dera.page/#yaojingang/GEOFlow&Date)

--- a/docs/readme/README_es.md
+++ b/docs/readme/README_es.md
@@ -302,4 +302,4 @@ GEOFlow está licenciado bajo la [Apache License 2.0](../../LICENSE). Permite us
 
 ## ⭐ Tendencia de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.com/#yaojingang/GEOFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.dera.page/#yaojingang/GEOFlow&Date)

--- a/docs/readme/README_ja.md
+++ b/docs/readme/README_ja.md
@@ -312,4 +312,4 @@ GEOFlow は [Apache License 2.0](../../LICENSE) の下で提供されます。�
 
 ## ⭐ スター推移
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.com/#yaojingang/GEOFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.dera.page/#yaojingang/GEOFlow&Date)

--- a/docs/readme/README_pt_BR.md
+++ b/docs/readme/README_pt_BR.md
@@ -315,4 +315,4 @@ GEOFlow é software livre sob a [Licença Apache 2.0](../../LICENSE).
 
 ## ⭐ Histórico de Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.com/#yaojingang/GEOFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.dera.page/#yaojingang/GEOFlow&Date)

--- a/docs/readme/README_ru.md
+++ b/docs/readme/README_ru.md
@@ -302,4 +302,4 @@ GEOFlow распространяется по [Apache License 2.0](../../LICENSE
 
 ## ⭐ Динамика звёзд
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.com/#yaojingang/GEOFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yaojingang/GEOFlow&type=Date)](https://star-history.dera.page/#yaojingang/GEOFlow&Date)


### PR DESCRIPTION
The star history chart in our READMEs is currently broken due to GitHub stargazer API restrictions. This PR migrates the chart to star-history.dera.page, which serves the same chart without requiring an API token. Updated README.md and all localized README versions.