### PR TITLE
fix(admin): remove redundant AI quality risk banner

### DIFF
--- a/resources/views/admin/articles/form.blade.php
+++ b/resources/views/admin/articles/form.blade.php
@@ -125,14 +125,6 @@
     ];
     $aiQualityIssues = is_array($aiQualityCheck?->issues) ? $aiQualityCheck->issues : [];
     $aiQualityUncertainties = is_array($aiQualityCheck?->uncertainties) ? $aiQualityCheck->uncertainties : [];
-    $hasPublishedAiQualityRisk = $isEdit
-        && $formData['status'] === 'published'
-        && $aiQualityEnabled
-        && (
-            ! $aiQualityCheck
-            || $aiQualityStatus !== 'completed'
-            || ($aiQualityDecision !== 'passed' && ! (bool) $aiQualityCheck?->is_overridden)
-        );
     $qualityFieldChecks = [
         [
             'label' => __('admin.articles.quality_scorecard.check_excerpt'),
@@ -298,18 +290,6 @@
                                     </button>
                                 </div>
                             </div>
-
-                            @if($hasPublishedAiQualityRisk)
-                                <div class="border-b border-red-200 bg-red-50 px-6 py-4" role="alert">
-                                    <div class="flex items-start gap-3 text-red-900">
-                                        <i data-lucide="triangle-alert" class="mt-0.5 h-5 w-5 shrink-0 text-red-600"></i>
-                                        <div>
-                                            <p class="text-sm font-semibold">{{ __('admin.articles.ai_quality.published_risk_title') }}</p>
-                                            <p class="mt-1 text-sm leading-6 text-red-800">{{ __('admin.articles.ai_quality.published_risk_desc') }}</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            @endif
 
                             @if(! $aiQualityEnabled && ! $aiQualityCheck)
                                 <div class="px-6 py-6 text-sm text-gray-600">

--- a/tests/Feature/AdminArticleAiQualityTest.php
+++ b/tests/Feature/AdminArticleAiQualityTest.php
@@ -478,7 +478,7 @@ class AdminArticleAiQualityTest extends TestCase
         }
     }
 
-    public function test_published_article_with_a_failed_latest_check_shows_a_published_content_risk_warning(): void
+    public function test_published_article_with_a_failed_latest_check_hides_the_redundant_risk_banner(): void
     {
         [$admin, $article] = $this->qualityArticle();
         $check = app(ArticleAiQualityInspectionService::class)->createOrReuse($article, dispatch: false);
@@ -499,8 +499,10 @@ class AdminArticleAiQualityTest extends TestCase
         $this->actingAs($admin, 'admin')
             ->get(route('admin.articles.edit', ['articleId' => $article->id]))
             ->assertOk()
-            ->assertSee(__('admin.articles.ai_quality.published_risk_title'))
-            ->assertSee(__('admin.articles.ai_quality.published_risk_desc'));
+            ->assertDontSee(__('admin.articles.ai_quality.published_risk_title'))
+            ->assertDontSee(__('admin.articles.ai_quality.published_risk_desc'))
+            ->assertSee(__('admin.articles.ai_quality.blocked'))
+            ->assertSee('关键事实与知识库不一致。');
 
         $this->assertSame('published', $article->fresh()->status);
     }


### PR DESCRIPTION
## Summary

- Remove the redundant red published-content-risk banner from the AI quality card.
- Keep AI quality results, failure details, retry actions, and backend publication gates unchanged.
- Add regression coverage for the hidden banner while retaining the publication-gate test.

## Verification

- `php artisan test tests/Feature/AdminArticleAiQualityTest.php tests/Feature/AdminArticlesPageTest.php`
- `php artisan view:cache` and `php artisan view:clear`
- `vendor/bin/pint --test tests/Feature/AdminArticleAiQualityTest.php`
- `git diff --check`