### PR TITLE
fix(admin): restore knowledge outline in fullscreen

### DIFF
--- a/resources/views/admin/knowledge-bases/detail.blade.php
+++ b/resources/views/admin/knowledge-bases/detail.blade.php
@@ -21,10 +21,15 @@
 @push('styles')
     <link rel="stylesheet" href="{{ asset('vendor/vditor/dist/index.css') }}">
     <style>
-        .knowledge-markdown-editor .vditor {
+        .knowledge-markdown-editor.vditor {
+            background: #fff;
             border: 0;
             border-radius: 0 0 0.75rem 0.75rem;
             min-height: 720px;
+        }
+
+        .knowledge-markdown-editor.vditor--fullscreen {
+            border-radius: 0;
         }
 
         .knowledge-markdown-editor .vditor-toolbar {
@@ -147,7 +152,7 @@
         }
 
         @media (max-width: 1023px) {
-            .knowledge-markdown-editor .vditor-outline {
+            .knowledge-markdown-editor:not(.vditor--fullscreen) .vditor-outline {
                 display: none !important;
             }
         }

--- a/tests/Feature/AdminMaterialsPagesTest.php
+++ b/tests/Feature/AdminMaterialsPagesTest.php
@@ -1768,7 +1768,15 @@ class AdminMaterialsPagesTest extends TestCase
             ->assertSee('outline: {', false)
             ->assertSee('enable: true', false)
             ->assertSee("position: 'left'", false)
-            ->assertSee('data-knowledge-outline-levels="1,2,3,4"', false);
+            ->assertSee('data-knowledge-outline-levels="1,2,3,4"', false)
+            ->assertSee('.knowledge-markdown-editor:not(.vditor--fullscreen) .vditor-outline {', false)
+            ->assertSeeInOrder([
+                '.knowledge-markdown-editor.vditor {',
+                'background: #fff;',
+                'border: 0;',
+                '.knowledge-markdown-editor.vditor--fullscreen {',
+                'border-radius: 0;',
+            ], false);
     }
 
     public function test_admin_can_manage_keyword_and_title_details(): void


### PR DESCRIPTION
## Summary

- Apply the white background and fullscreen radius styles to the Vditor root.
- Keep narrow-screen outline hiding limited to non-fullscreen mode.
- Add regression coverage for the selector and fullscreen styles.

## Verification

- `php artisan test --filter=test_knowledge_editor_exposes_a_left_heading_navigation_tree tests/Feature/AdminMaterialsPagesTest.php`
- `php artisan test` (2370 passed, 23330 assertions)
- Browser validation at 1023px in normal and fullscreen modes