### PR TITLE
fix: tolerate missing structured_output in AI source provider model test

### DIFF
--- a/app/Http/Controllers/Admin/AiSourceProviderController.php
+++ b/app/Http/Controllers/Admin/AiSourceProviderController.php
@@ -663,7 +663,7 @@ class AiSourceProviderController extends Controller
                 'http_status' => $result['http_status'],
                 'latency_ms' => $result['latency_ms'],
                 'endpoint' => $result['endpoint'],
-                'structured_output' => $result['structured_output'],
+                'structured_output' => $result['structured_output'] ?? [],
                 'answer_preview' => $result['raw_preview'],
                 'workspace_readiness' => $result['profile'] ?? null,
                 'workspace_readiness_expires_at' => $result['expires_at'] ?? null,

--- a/tests/Feature/AdminAiSourceProvidersPageTest.php
+++ b/tests/Feature/AdminAiSourceProvidersPageTest.php
@@ -657,6 +657,51 @@ class AdminAiSourceProvidersPageTest extends TestCase
         $this->assertSame(now()->toDateString(), $model->usage_date?->toDateString());
     }
 
+    public function test_super_admin_probe_result_without_structured_output_key_does_not_crash(): void
+    {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.deepseek.com/v1/chat/completions' => Http::response(
+                "data: {\"id\":\"1\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\\u4f60\\u597d\"},\"finish_reason\":null}]}\n\n"
+                ."data: {\"id\":\"1\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\\uff0c\"},\"finish_reason\":null}]}\n\n"
+                ."data: {\"id\":\"1\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+                ."data: [DONE]\n\n",
+                200,
+                ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $model = $this->createAiModel([
+            'name' => 'DeepSeek Super Admin Probe',
+            'model_id' => 'deepseek-v4-flash',
+            'api_url' => 'https://api.deepseek.com',
+        ]);
+
+        $superAdmin = Admin::query()->create([
+            'username' => 'deepseek_super_probe_admin',
+            'password' => 'secret-123',
+            'email' => 'deepseek-super-probe-admin@example.com',
+            'display_name' => 'DeepSeek Super Probe Admin',
+            'role' => 'super_admin',
+            'status' => 'active',
+        ]);
+
+        $response = $this->actingAs($superAdmin, 'admin')
+            ->postJson(route('admin.ai-source-providers.model-bindings.test'), [
+                'binding_type' => 'deepseek',
+                'model_id' => (int) $model->id,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('meta.structured_output', [])
+            ->assertJsonPath('meta.workspace_readiness.configuration.status', 'ready')
+            ->assertJsonPath('meta.workspace_readiness.streaming.status', 'ready');
+
+        $model->refresh();
+        $this->assertSame('ready', (string) $model->ai_workspace_readiness_status);
+    }
+
     public function test_failed_model_binding_test_attempt_consumes_daily_quota(): void
     {
         Http::preventStrayRequests();


### PR DESCRIPTION
Super admins testing a DeepSeek/Ark binding go through AiWorkspaceModelCapabilityProbe, whose result does not include the structured_output key, so structuredTestResponse() crashed with "Undefined array key structured_output" (surfaced as test failure). Default the key to an empty array and add a regression test that covers the super-admin probe path via a streamed probe response.

## 变更说明 / Summary

<!-- 说明问题、解决方式和影响范围。Describe the problem, solution, and scope. -->

## 验证 / Verification

<!-- 列出实际执行的测试或检查。List the tests or checks you ran. -->

## CLA 声明 / CLA declaration

可构成版权作品的贡献必须接受 [GEOFlow Contributor License Agreement v1.0](https://github.com/yaojingang/GEOFlow/blob/main/CLA.md)。
Copyrightable contributions require acceptance of the [GEOFlow Contributor License Agreement v1.0](https://github.com/yaojingang/GEOFlow/blob/main/CLA.md).

以下内容会公开显示。如需私下签署，请将姓名字段填写为 `Private CLA requested`，并在合并前与维护者完成单独签署。
The following information is public. To sign privately, enter `Private CLA requested` in the name field and complete a separate signature with the maintainer before merge.

- 贡献者类型 / Contributor type: `个人 Individual` / `企业 Entity`
- 法定姓名或企业法定名称 / Legal name or entity name:
- 企业授权代表姓名及职务（如适用）/ Authorized representative and title (if applicable):
- GitHub 用户名 / GitHub username:
- 接受日期 / Date accepted (`YYYY-MM-DD`):
- [x] 我已阅读并接受 GEOFlow CLA v1.0，并确认有权授予其中约定的权利。I have read and accept the GEOFlow CLA v1.0 and confirm that I have authority to grant the rights described in it.

## 检查清单 / Checklist

- [x] 我已说明第三方材料的来源、许可证和修改情况，或本次提交不包含第三方材料。
      I have identified the source, license, and modifications of third-party materials, or this contribution contains none.
- [x] 我没有提交凭据、客户数据或其他敏感信息。
      I have not submitted credentials, customer data, or other sensitive information.
- [x] 我已为行为变化补充测试或说明无需新增测试的原因。
      I have added tests for behavior changes or explained why no new test is needed.
