### PR TITLE
fix(admin): keep settings navigation visible

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -242,7 +242,7 @@ html[data-gf-sidebar-resizing] body { cursor: col-resize; user-select: none; }
 .gf-popover--user .gf-popover__danger { color: var(--gf-red-600); }
 
 .gf-main { background: var(--gf-gray-50); display: flex; flex: 1 1 auto; flex-direction: column; min-height: 0; min-width: 0; overflow-y: auto; overscroll-behavior: contain; }
-.gf-context-nav { background: var(--gf-gray-50); overflow-x: auto; scrollbar-width: none; }
+.gf-context-nav { background: var(--gf-gray-50); flex: 0 0 auto; overflow-x: auto; scrollbar-width: none; }
 .gf-context-nav::-webkit-scrollbar { display: none; }
 .gf-context-nav__inner { align-items: end; display: flex; gap: 24px; margin: 0 auto; max-width: var(--gf-content-max); min-width: max-content; padding: 28px 48px 0; }
 .gf-content { flex: 0 0 auto; margin: 0 auto; max-width: var(--gf-content-max); padding: 28px 48px 48px; width: 100%; }

--- a/tests/Feature/AdminUiV3FullPageSmokeTest.php
+++ b/tests/Feature/AdminUiV3FullPageSmokeTest.php
@@ -105,12 +105,32 @@ class AdminUiV3FullPageSmokeTest extends TestCase
             $topbarIdentities = $xpath->query('//*[@data-gf-topbar-identity]');
             $content = $xpath->query('//main[@id="main-content"]//*[@data-gf-page-heading]')?->item(0);
             $identity = $registry->pageIdentity($routeName);
+            $settingsNavigations = $xpath->query('//*[@data-settings-navigation]');
 
             $this->assertSame(1, $headings?->length, $routeName.' must render exactly one page title');
             $this->assertSame(1, $topbarIdentities?->length, $routeName.' must render one topbar identity');
             $this->assertSame($identity['icon'], $topbarIdentities?->item(0)?->attributes?->getNamedItem('data-page-icon')?->nodeValue, $routeName);
             $this->assertSame($identity['body_heading'], $content?->attributes?->getNamedItem('data-gf-page-heading')?->nodeValue, $routeName);
             $this->assertStringContainsString($identity['title'], $topbarIdentities?->item(0)?->textContent ?? '', $routeName);
+
+            $showsSettingsNavigation = $registry->activeKey($routeName) === 'site_settings'
+                && ! str_starts_with($routeName, 'admin.account.');
+            $this->assertSame($showsSettingsNavigation ? 1 : 0, $settingsNavigations?->length, $routeName);
+
+            if ($showsSettingsNavigation) {
+                $settingsNavigation = $settingsNavigations?->item(0);
+                $activeSettingsItems = $xpath->query('.//*[@aria-current="page"]', $settingsNavigation);
+                $expectedActiveItem = collect($registry->settingsNavigation($admin, $routeName))
+                    ->firstWhere('active', true);
+
+                $this->assertIsArray($expectedActiveItem, $routeName);
+                $this->assertSame(1, $activeSettingsItems?->length, $routeName);
+                $this->assertSame(
+                    $expectedActiveItem['key'],
+                    $activeSettingsItems?->item(0)?->attributes?->getNamedItem('data-settings-navigation-item')?->nodeValue,
+                    $routeName,
+                );
+            }
         }
     }
 

--- a/tests/Unit/AdminContextNavigationStyleTest.php
+++ b/tests/Unit/AdminContextNavigationStyleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class AdminContextNavigationStyleTest extends TestCase
+{
+    public function test_context_navigation_keeps_its_height_when_page_content_exceeds_the_viewport(): void
+    {
+        $css = (string) file_get_contents(dirname(__DIR__, 2).'/resources/css/app.css');
+
+        self::assertStringContainsString(
+            'flex: 0 0 auto;',
+            $this->declarationsFor($css, '.gf-context-nav'),
+        );
+    }
+
+    private function declarationsFor(string $css, string $selector): string
+    {
+        $matches = [];
+        $matched = preg_match('/(?:^|})\s*'.preg_quote($selector, '/').'\s*\{(?<declarations>[^}]*)\}/', $css, $matches);
+
+        self::assertSame(1, $matched, "Missing CSS selector: {$selector}");
+
+        return (string) $matches['declarations'];
+    }
+}


### PR DESCRIPTION
## 变更说明 / Summary

- 修复长内容页面中网站设置二级菜单被纵向 Flex 布局压缩为零高度的问题。
- 固定上下文菜单的高度，让网站设置首页及相关二级页面保持统一导航样式。
- 扩展后台全页面冒烟测试，校验所有网站设置相关页面的菜单出现规则、唯一激活项和分组归属。
- 新增菜单高度回归测试，防止后续样式调整再次遗漏。

## 验证 / Verification

- 相关后台测试：17 passed，1239 assertions
- 完整 PHP 测试：2373 passed，23555 assertions
- 前端测试：176 passed
- 前端生产构建通过
- PHP 代码格式、Composer 清单和差异格式检查通过
- Composer 与 npm 安全审计均为 0 个漏洞

## 检查清单 / Checklist

- [x] 本次提交不包含第三方材料
- [x] 本次提交不包含凭据、客户数据或其他敏感信息
- [x] 已为行为变化补充回归测试