### PR TITLE
fix: redact updater credentials from exception traces

### DIFF
--- a/app/Services/SystemUpdater/UnixSocketAgentClient.php
+++ b/app/Services/SystemUpdater/UnixSocketAgentClient.php
@@ -27,19 +27,19 @@ class UnixSocketAgentClient implements AgentClient
     }
 
     /** @return array<string, mixed> */
-    public function startUpdate(string $authorizationCode): array
+    public function startUpdate(#[\SensitiveParameter] string $authorizationCode): array
     {
         return $this->startOperation('updates', 'update', $authorizationCode);
     }
 
     /** @return array<string, mixed> */
-    public function startBackup(string $authorizationCode): array
+    public function startBackup(#[\SensitiveParameter] string $authorizationCode): array
     {
         return $this->startOperation('backups', 'backup', $authorizationCode);
     }
 
     /** @return array<string, mixed> */
-    public function startRollback(string $recoveryPointId, string $authorizationCode): array
+    public function startRollback(string $recoveryPointId, #[\SensitiveParameter] string $authorizationCode): array
     {
         if (preg_match('/\A[0-9]{8}T[0-9]{6}Z-[a-f0-9]{8}\z/', $recoveryPointId) !== 1) {
             throw new RuntimeException('Updater recovery point identifier is invalid.');
@@ -103,7 +103,7 @@ class UnixSocketAgentClient implements AgentClient
     }
 
     /** @return array<string, mixed> */
-    private function startOperation(string $endpoint, string $kind, ?string $authorizationCode = null): array
+    private function startOperation(string $endpoint, string $kind, #[\SensitiveParameter] ?string $authorizationCode = null): array
     {
         if ($authorizationCode !== null) {
             $this->validateAuthorizationCode($authorizationCode);
@@ -206,7 +206,7 @@ class UnixSocketAgentClient implements AgentClient
      * @param  array<string, mixed>|null  $payload
      * @return array{0: int, 1: array<string, mixed>}
      */
-    private function instanceRequest(string $method, string $endpoint, ?array $payload = null, ?string $authorizationCode = null): array
+    private function instanceRequest(string $method, string $endpoint, ?array $payload = null, #[\SensitiveParameter] ?string $authorizationCode = null): array
     {
         $socketPath = (string) config('geoflow.updater_socket');
         $tokenPath = (string) config('geoflow.updater_control_token_file');
@@ -269,7 +269,7 @@ class UnixSocketAgentClient implements AgentClient
     }
 
     /** @return array{0: int, 1: string} */
-    private function request(string $socketPath, string $method, string $path, string $token, string $body, ?string $authorizationCode): array
+    private function request(string $socketPath, string $method, string $path, #[\SensitiveParameter] string $token, string $body, #[\SensitiveParameter] ?string $authorizationCode): array
     {
         $socketInfo = @lstat($socketPath);
         if (! is_array($socketInfo) || (($socketInfo['mode'] ?? 0) & 0170000) !== 0140000) {
@@ -344,7 +344,7 @@ class UnixSocketAgentClient implements AgentClient
         return [(int) $matches[1], $responseBody];
     }
 
-    private function validateAuthorizationCode(string $authorizationCode): void
+    private function validateAuthorizationCode(#[\SensitiveParameter] string $authorizationCode): void
     {
         if (preg_match('/\A[0-9]{6}\z/', $authorizationCode) !== 1) {
             throw new RuntimeException('Updater mutation authorization code is invalid.');

--- a/docker/php/php-docker-overrides.ini
+++ b/docker/php/php-docker-overrides.ini
@@ -1,5 +1,7 @@
 ; 容器内 PHP 通用项（与 OPcache 互补）
 expose_php=Off
+; 保留异常位置与调用栈，省略可能包含凭据的函数参数。
+zend.exception_ignore_args=On
 realpath_cache_size=4096K
 realpath_cache_ttl=600
 

--- a/tests/Unit/PhpExceptionLoggingConfigurationTest.php
+++ b/tests/Unit/PhpExceptionLoggingConfigurationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class PhpExceptionLoggingConfigurationTest extends TestCase
+{
+    public function test_container_php_configuration_omits_exception_arguments_and_preserves_diagnostics(): void
+    {
+        $probe = <<<'PHP'
+        function failWithCredential(string $credential): never {
+            throw new RuntimeException('protected operation failed');
+        }
+        $credential = 'fixture-credential-604827';
+        try {
+            failWithCredential($credential);
+        } catch (RuntimeException $exception) {
+            $log = (string) $exception;
+            echo json_encode([
+                'credential_present' => str_contains($log, $credential),
+                'reason_present' => str_contains($log, 'protected operation failed'),
+                'stack_present' => str_contains($log, 'failWithCredential('),
+            ], JSON_THROW_ON_ERROR);
+        }
+        PHP;
+
+        $unprotected = $this->runProbe(['-n', '-d', 'zend.exception_ignore_args=0'], $probe);
+        $this->assertSame([
+            'credential_present' => true,
+            'reason_present' => true,
+            'stack_present' => true,
+        ], $unprotected);
+
+        $protected = $this->runProbe(['-c', dirname(__DIR__, 2).'/docker/php/php-docker-overrides.ini'], $probe);
+        $this->assertSame([
+            'credential_present' => false,
+            'reason_present' => true,
+            'stack_present' => true,
+        ], $protected);
+    }
+
+    private function runProbe(array $settings, string $probe): array
+    {
+        $process = new Process(
+            [PHP_BINARY, ...$settings, '-d', 'zend.exception_string_param_max_len=128', '-r', $probe],
+            env: ['PHP_INI_SCAN_DIR' => ''],
+        );
+        $process->mustRun();
+
+        return json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Unit/UnixSocketAgentClientTest.php
+++ b/tests/Unit/UnixSocketAgentClientTest.php
@@ -3,11 +3,106 @@
 namespace Tests\Unit;
 
 use App\Services\SystemUpdater\UnixSocketAgentClient;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Tests\TestCase;
 
 class UnixSocketAgentClientTest extends TestCase
 {
+    public function test_rejected_rollback_keeps_diagnostic_context_without_logging_the_authorization_code(): void
+    {
+        $previous = ini_get('zend.exception_ignore_args');
+        ini_set('zend.exception_ignore_args', '0');
+        $authorizationCode = '604827';
+
+        try {
+            $this->assertStringContainsString($authorizationCode, $this->formatException(new RuntimeException($authorizationCode)));
+            try {
+                $this->withAgentResponse(
+                    ['error' => 'rollback_target_not_allowed'],
+                    fn (UnixSocketAgentClient $client): array => $client->startRollback('20260827T120000Z-1234abcd', $authorizationCode),
+                    409,
+                );
+                $this->fail('The rejected rollback must throw an exception.');
+            } catch (RuntimeException $exception) {
+                $log = $this->formatException($exception);
+                $this->assertStringContainsString('rollback_target_not_allowed', $log);
+                $this->assertStringContainsString('UnixSocketAgentClient->startRollback(', $log);
+                $this->assertStringNotContainsString($authorizationCode, $log);
+            }
+        } finally {
+            ini_set('zend.exception_ignore_args', (string) $previous);
+        }
+    }
+
+    private function formatException(\Throwable $exception): string
+    {
+        return (new LineFormatter(null, 'Y-m-d H:i:s', true, true, true))->format(new LogRecord(
+            new \DateTimeImmutable,
+            'updater-test',
+            Level::Error,
+            $exception->getMessage(),
+            ['exception' => $exception],
+        ));
+    }
+
+    #[DataProvider('mutationFailureCases')]
+    public function test_mutation_failures_redact_credentials_even_when_exception_arguments_are_enabled(string $method, string $failure): void
+    {
+        $previous = ini_get('zend.exception_ignore_args');
+        $previousLength = ini_get('zend.exception_string_param_max_len');
+        ini_set('zend.exception_ignore_args', '0');
+        ini_set('zend.exception_string_param_max_len', '128');
+        $authorizationCode = $failure === 'validation' ? '604827bad' : '604827';
+        $controlToken = str_repeat('c', 43);
+        $expectedReason = match ($failure) {
+            'validation' => 'authorization code is invalid',
+            'transport' => 'invalid HTTP response',
+            default => 'mutation_rejected',
+        };
+
+        try {
+            $positive = $this->formatException(new RuntimeException($authorizationCode.' '.$controlToken));
+            $this->assertStringContainsString($authorizationCode, $positive);
+            $this->assertStringContainsString($controlToken, $positive);
+            $invoke = fn (UnixSocketAgentClient $client): array => $method === 'startRollback'
+                ? $client->startRollback('20260827T120000Z-1234abcd', $authorizationCode)
+                : $client->{$method}($authorizationCode);
+            try {
+                if ($failure === 'validation') {
+                    $invoke(new UnixSocketAgentClient);
+                } else {
+                    $this->withAgentResponse(['error' => 'mutation_rejected'], $invoke, $failure === 'transport' ? 0 : 409);
+                }
+                $this->fail('The failed mutation must throw an exception.');
+            } catch (RuntimeException $exception) {
+                $log = $this->formatException($exception);
+                $this->assertStringContainsString($expectedReason, $log);
+                $this->assertStringContainsString('UnixSocketAgentClient->'.$method.'(', $log);
+                $this->assertStringNotContainsString($authorizationCode, $log);
+                $this->assertStringNotContainsString($controlToken, $log);
+            }
+        } finally {
+            ini_set('zend.exception_ignore_args', (string) $previous);
+            ini_set('zend.exception_string_param_max_len', (string) $previousLength);
+        }
+    }
+
+    public static function mutationFailureCases(): array
+    {
+        $cases = [];
+        foreach (['startUpdate', 'startBackup', 'startRollback'] as $method) {
+            foreach (['rejected', 'transport', 'validation'] as $failure) {
+                $cases[$method.' '.$failure] = [$method, $failure];
+            }
+        }
+
+        return $cases;
+    }
+
     public function test_it_reads_authenticated_status_from_the_local_unix_socket(): void
     {
         $directory = sys_get_temp_dir().'/geoflow-updater-client-'.bin2hex(random_bytes(8));
@@ -288,7 +383,7 @@ class UnixSocketAgentClientTest extends TestCase
      * @param  callable(UnixSocketAgentClient): T  $callback
      * @return T
      */
-    private function withAgentResponse(array $payload, callable $callback): mixed
+    private function withAgentResponse(array $payload, callable $callback, int $httpStatus = 200): mixed
     {
         $directory = sys_get_temp_dir().'/geoflow-updater-client-'.bin2hex(random_bytes(8));
         mkdir($directory, 0700, true);
@@ -311,7 +406,7 @@ class UnixSocketAgentClientTest extends TestCase
                     }
                 }
                 $body = json_encode($payload, JSON_THROW_ON_ERROR);
-                fwrite($connection, "HTTP/1.0 200 OK\r\nContent-Type: application/json\r\nContent-Length: ".strlen($body)."\r\n\r\n".$body);
+                fwrite($connection, "HTTP/1.0 {$httpStatus} Response\r\nContent-Type: application/json\r\nContent-Length: ".strlen($body)."\r\n\r\n".$body);
                 fclose($connection);
             }
             fclose($server);


### PR DESCRIPTION
Protect updater authorization codes and the control token from PHP exception traces. All seven credential-carrying client methods now mark their sensitive parameters, and the shared container PHP configuration omits exception arguments while retaining error reasons and stack locations. Authentication, CSRF, request validation, filesystem modes, socket permissions and runtime users are unchanged.

The new regressions exercise real Unix-socket rejection/transport paths and actual Monolog output, plus a subprocess using the container INI. Each non-disclosure check has a positive control. The rollback regression failed before its fix; eight remaining mutation failure cases then failed before the sibling annotations; the production INI regression also failed before its fix. All targeted checks now pass, including the administrator bridge suite (52 tests / 336 assertions).

The full default PHP suite completed with 3123 tests and 32470 assertions, no failures and one expected PostgreSQL-only skip under SQLite. The GitHub PostgreSQL job covers that separate runtime. Pint and diff checks passed. Independent security review found no introduced issue.

This change requires a new frozen Core SHA and a rebuilt candidate, followed by the strict native amd64/arm64 rehearsal. No release, stable TUF target or local deployment is changed by this PR.
