### PR TITLE
fix: remove invalid empty-string comparison on uuid lease token columns (PostgreSQL 22P02)

### DIFF
--- a/app/Services/GeoFlow/EnterpriseKnowledgeDraftRecoveryService.php
+++ b/app/Services/GeoFlow/EnterpriseKnowledgeDraftRecoveryService.php
@@ -21,7 +21,6 @@ final class EnterpriseKnowledgeDraftRecoveryService
             ->where('status', 'processing')
             ->where(function ($query): void {
                 $query->whereNull('execution_lease_token')
-                    ->orWhere('execution_lease_token', '')
                     ->orWhere(function ($expired): void {
                         $expired->whereNotNull('lease_expires_at')
                             ->where('lease_expires_at', '<=', now());

--- a/app/Services/GeoFlow/UrlImportRecoveryService.php
+++ b/app/Services/GeoFlow/UrlImportRecoveryService.php
@@ -21,7 +21,6 @@ final class UrlImportRecoveryService
             ->where('status', 'running')
             ->where(function ($query): void {
                 $query->whereNull('execution_lease_token')
-                    ->orWhere('execution_lease_token', '')
                     ->orWhere(function ($expired): void {
                         $expired->whereNotNull('lease_expires_at')
                             ->where('lease_expires_at', '<=', now());

--- a/tests/PostgreSQL/ExecutionLeaseRecoveryQueryTest.php
+++ b/tests/PostgreSQL/ExecutionLeaseRecoveryQueryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\PostgreSQL;
+
+use App\Jobs\GenerateEnterpriseKnowledgeDraftJob;
+use App\Jobs\ProcessUrlImportJob;
+use App\Models\EnterpriseKnowledgeProject;
+use App\Models\UrlImportJob;
+use App\Services\GeoFlow\EnterpriseKnowledgeDraftRecoveryService;
+use App\Services\GeoFlow\UrlImportRecoveryService;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ExecutionLeaseRecoveryQueryTest extends PostgreSqlTestCase
+{
+    use DatabaseMigrations;
+
+    #[DataProvider('recoveryServices')]
+    public function test_recovery_queries_handle_native_uuid_leases(
+        string $modelClass,
+        string $serviceClass,
+        string $jobClass,
+        string $runningStatus,
+        array $attributes,
+    ): void {
+        Queue::fake();
+
+        $missing = $modelClass::query()->create(array_merge($attributes, [
+            'status' => $runningStatus,
+            'execution_lease_token' => null,
+            'lease_expires_at' => null,
+        ]));
+        $expired = $modelClass::query()->create(array_merge($attributes, [
+            'status' => $runningStatus,
+            'execution_lease_token' => (string) Str::uuid(),
+            'lease_expires_at' => now()->subMinute(),
+        ]));
+        $activeToken = (string) Str::uuid();
+        $active = $modelClass::query()->create(array_merge($attributes, [
+            'status' => $runningStatus,
+            'execution_lease_token' => $activeToken,
+            'lease_expires_at' => now()->addHour(),
+        ]));
+        $completed = $modelClass::query()->create(array_merge($attributes, [
+            'status' => 'completed',
+            'execution_lease_token' => null,
+            'lease_expires_at' => null,
+        ]));
+
+        $service = app($serviceClass);
+        $this->assertSame(['recovered' => 2, 'dispatch_failed' => 0], $service->reconcile());
+        Queue::assertPushed($jobClass, 2);
+        foreach ([$missing, $expired] as $recovered) {
+            $recovered->refresh();
+            $this->assertSame('queued', $recovered->status);
+            $this->assertNull($recovered->execution_lease_token);
+            $this->assertNull($recovered->lease_expires_at);
+        }
+        $this->assertSame($runningStatus, $active->refresh()->status);
+        $this->assertSame($activeToken, $active->execution_lease_token);
+        $this->assertSame('completed', $completed->refresh()->status);
+        $this->assertSame(['recovered' => 0, 'dispatch_failed' => 0], $service->reconcile());
+        Queue::assertPushed($jobClass, 2);
+    }
+
+    public static function recoveryServices(): array
+    {
+        return [
+            'enterprise knowledge' => [
+                EnterpriseKnowledgeProject::class,
+                EnterpriseKnowledgeDraftRecoveryService::class,
+                GenerateEnterpriseKnowledgeDraftJob::class,
+                'processing',
+                ['name' => 'PostgreSQL recovery project'],
+            ],
+            'URL import' => [
+                UrlImportJob::class,
+                UrlImportRecoveryService::class,
+                ProcessUrlImportJob::class,
+                'running',
+                ['url' => 'https://example.test/recovery', 'normalized_url' => 'https://example.test/recovery'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## 问题

`EnterpriseKnowledgeDraftRecoveryService` 和 `UrlImportRecoveryService` 的恢复查询中,对 `execution_lease_token`(uuid 类型列)使用了 `orWhere('execution_lease_token', '')` 比较。

PostgreSQL 无法把空字符串转换为 uuid,该查询**每次执行必然抛出 22P02 错误**(`invalid input syntax for type uuid: ""`)。这两个恢复命令由调度器周期运行,导致生产日志持续报错。

## 修复

空串在 uuid 列中本就不可能存在,直接移除该死分支,保留「token 为 NULL 或租约已过期」的原语义。

## 验证

- `geoflow:recover-enterprise-knowledge-drafts` 与 `geoflow:recover-url-imports` 在 PostgreSQL 16/18 上运行通过,不再报错
- 已在生产实例(3.0.0)验证