### PR TITLE
fix: drop empty-array Sites/BlockHosts from Doubao search filter (API 10400)

### DIFF
--- a/app/Services/GeoFlow/AiVisibility/DoubaoSearchCustomClient.php
+++ b/app/Services/GeoFlow/AiVisibility/DoubaoSearchCustomClient.php
@@ -66,7 +66,7 @@ final class DoubaoSearchCustomClient
             'BlockHosts' => $options['block_hosts'] ?? null,
             'TimeRange' => $options['time_range'] ?? null,
             'ContentFormats' => $options['content_formats'] ?? 'Markdown',
-        ], static fn (mixed $value): bool => $value !== null && $value !== '');
+        ], static fn (mixed $value): bool => $value !== null && $value !== '' && $value !== []);
 
         return array_filter([
             'Query' => $query,

--- a/tests/Feature/AiVisibilityServiceTest.php
+++ b/tests/Feature/AiVisibilityServiceTest.php
@@ -304,6 +304,65 @@ class AiVisibilityServiceTest extends TestCase
         $this->assertSame(1, (int) $model->fresh()->used_today);
     }
 
+    public function test_search_omits_empty_site_filters_saved_in_provider_metadata(): void
+    {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://open.feedcoopapi.com/search_api/web_search' => Http::response([
+                'Result' => ['WebResults' => []],
+            ]),
+        ]);
+        $provider = $this->createSearchProvider([
+            'metadata_json' => [
+                'sites' => [],
+                'block_hosts' => [],
+                'need_content' => false,
+                'need_url' => false,
+            ],
+        ]);
+
+        $run = app(AiVisibilityService::class)->runDoubaoSearchCustom($provider, 'GEOFlow');
+
+        $this->assertSame(AiVisibilityRun::STATUS_COMPLETED, $run->status);
+        Http::assertSentCount(1);
+        Http::assertSent(function ($request): bool {
+            $filter = $request->data()['Filter'];
+
+            return ! array_key_exists('Sites', $filter)
+                && ! array_key_exists('BlockHosts', $filter)
+                && $filter['NeedContent'] === false
+                && $filter['NeedUrl'] === false
+                && $filter['ContentFormats'] === 'Markdown';
+        });
+    }
+
+    public function test_search_preserves_non_empty_site_filters_saved_in_provider_metadata(): void
+    {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://open.feedcoopapi.com/search_api/web_search' => Http::response([
+                'Result' => ['WebResults' => []],
+            ]),
+        ]);
+        $provider = $this->createSearchProvider([
+            'metadata_json' => [
+                'sites' => ['example.com'],
+                'block_hosts' => ['blocked.example.com'],
+            ],
+        ]);
+
+        $run = app(AiVisibilityService::class)->runDoubaoSearchCustom($provider, 'GEOFlow');
+
+        $this->assertSame(AiVisibilityRun::STATUS_COMPLETED, $run->status);
+        Http::assertSentCount(1);
+        Http::assertSent(function ($request): bool {
+            $filter = $request->data()['Filter'];
+
+            return $filter['Sites'] === ['example.com']
+                && $filter['BlockHosts'] === ['blocked.example.com'];
+        });
+    }
+
     private function createSearchProvider(array $overrides = []): AiSourceProvider
     {
         return AiSourceProvider::query()->create(array_merge([


### PR DESCRIPTION
## 问题

后台「AI 信源提供商」表单保存后,provider metadata 会带有默认的 `"sites": []` 与 `"block_hosts": []`(空数组)。`DoubaoSearchCustomClient::buildPayload()` 的 `array_filter` 只过滤了 `null` 和 `''`,空数组会原样进入请求体的 `Filter`:

```json
{"Query":"...","Filter":{"NeedContent":true,"Sites":[],"BlockHosts":[],...}}
```

火山搜索 API 对空数组参数返回 `10400 Invalid Parameter`,导致 **AI 可见性采集(豆包搜索阶段)100% 失败**。

## 修复

`array_filter` 回调增加 `$value !== []`,与外层 Filter 的过滤条件保持一致;空数组不再进入请求。

## 验证

- 补丁后重建镜像,同样的 metadata(含空数组)也能正常采集
- 已在生产实例(3.0.0)验证