### PR TITLE
fix: prevent MiniMax reasoning from appearing in articles

### DIFF
--- a/app/Ai/Agents/MarkdownContentWriterAgent.php
+++ b/app/Ai/Agents/MarkdownContentWriterAgent.php
@@ -38,6 +38,7 @@ class MarkdownContentWriterAgent implements Agent, Conversational, HasProviderOp
         public iterable $messages = [],
         public iterable $tools = [],
         public ?int $maxTokens = null,
+        public bool $separateReasoning = false,
     ) {}
 
     /**
@@ -71,16 +72,19 @@ class MarkdownContentWriterAgent implements Agent, Conversational, HasProviderOp
      */
     public function providerOptions(Lab|string $provider): array
     {
+        $providerKey = $provider instanceof Lab ? $provider->value : $provider;
+        $options = $this->separateReasoning
+            ? ['reasoning_split' => true]
+            : [];
+
         if (is_null($this->maxTokens) || $this->maxTokens <= 0) {
-            return [];
+            return $options;
         }
 
-        $providerKey = $provider instanceof Lab ? $provider->value : $provider;
-
-        return match ($providerKey) {
+        return array_merge($options, match ($providerKey) {
             'gemini' => ['maxOutputTokens' => $this->maxTokens],
             'openai' => ['max_output_tokens' => $this->maxTokens],
             default => ['max_tokens' => $this->maxTokens],
-        };
+        });
     }
 }

--- a/app/Services/GeoFlow/ArticleContentGenerationService.php
+++ b/app/Services/GeoFlow/ArticleContentGenerationService.php
@@ -11,6 +11,8 @@ use Closure;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
 use RuntimeException;
 use Throwable;
 
@@ -43,7 +45,13 @@ final class ArticleContentGenerationService
             );
         }
 
-        if (OpenAiRuntimeProvider::normalizeGeneratedText((string) ($response->text ?? '')) === '') {
+        $normalized = OpenAiRuntimeProvider::normalizeGeneratedText($response->text);
+        $content = ArticleReasoningFilter::clean($normalized);
+        if ($content !== $normalized) {
+            $response->text = $content;
+        }
+
+        if (trim($content) === '') {
             $this->releaseDailyUsage($reservation);
 
             return $response;
@@ -141,9 +149,29 @@ final class ArticleContentGenerationService
             $upstream->invocationId,
             function () use ($upstream, $reservation, $providerUrl): iterable {
                 $streamEnded = false;
+                $filters = [];
+                $lastDeltas = [];
 
                 try {
                     foreach ($upstream as $event) {
+                        if ($event instanceof TextDelta) {
+                            $filter = $filters[$event->messageId] ??= new ArticleReasoningFilter;
+                            $lastDeltas[$event->messageId] = $event;
+                            $event = clone $event;
+                            $event->delta = $filter->push($event->delta);
+                            if ($event->delta === '') {
+                                continue;
+                            }
+                        } elseif ($event instanceof TextEnd && isset($filters[$event->messageId])) {
+                            $remaining = $filters[$event->messageId]->finish();
+                            if ($remaining !== '') {
+                                $lastDelta = clone $lastDeltas[$event->messageId];
+                                $lastDelta->delta = $remaining;
+                                yield $lastDelta;
+                            }
+                            unset($filters[$event->messageId], $lastDeltas[$event->messageId]);
+                        }
+
                         yield $event;
                     }
                     $streamEnded = true;
@@ -239,9 +267,12 @@ final class ArticleContentGenerationService
 
         $driver = OpenAiRuntimeProvider::resolveChatDriver($providerUrl, $modelId);
         $providerName = OpenAiRuntimeProvider::registerProvider($registrySlot, $driver, $providerUrl, $apiKey);
+        $host = strtolower((string) parse_url($providerUrl, PHP_URL_HOST));
+        $separateReasoning = in_array($host, ['api.minimaxi.com', 'api.minimax.io', 'api.minimax.cn'], true)
+            && str_starts_with(strtolower($modelId), 'minimax-m');
 
         return [
-            new MarkdownContentWriterAgent(maxTokens: $this->maxTokens($aiModel)),
+            new MarkdownContentWriterAgent(maxTokens: $this->maxTokens($aiModel), separateReasoning: $separateReasoning),
             $providerName,
             $modelId,
             $providerUrl,

--- a/app/Services/GeoFlow/ArticleReasoningFilter.php
+++ b/app/Services/GeoFlow/ArticleReasoningFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services\GeoFlow;
+
+final class ArticleReasoningFilter
+{
+    private string $buffer = '';
+
+    private bool $insideReasoning = false;
+
+    private bool $bodyStarted = false;
+
+    private bool $removedReasoning = false;
+
+    public static function clean(string $content): string
+    {
+        $filter = new self;
+
+        return $filter->push($content).$filter->finish();
+    }
+
+    public function push(string $delta): string
+    {
+        if ($this->bodyStarted) {
+            return $delta;
+        }
+
+        $this->buffer .= $delta;
+
+        while (true) {
+            if ($this->insideReasoning) {
+                $end = stripos($this->buffer, '</think>');
+                if ($end === false) {
+                    $this->buffer = substr($this->buffer, -7);
+
+                    return '';
+                }
+
+                $this->buffer = ltrim(substr($this->buffer, $end + 8));
+                $this->insideReasoning = false;
+            }
+
+            if ($this->removedReasoning) {
+                $this->buffer = ltrim($this->buffer);
+            }
+
+            $prefix = ltrim($this->buffer);
+            if ($prefix === '' || str_starts_with('<think', strtolower($prefix))) {
+                return '';
+            }
+
+            if (preg_match('/\A<think(?:\s[^>]*)?>/i', $prefix, $match) === 1) {
+                $this->buffer = substr($prefix, strlen($match[0]));
+                $this->insideReasoning = true;
+                $this->removedReasoning = true;
+
+                continue;
+            }
+
+            if (preg_match('/\A<think\s[^>]*\z/i', $prefix) === 1) {
+                return '';
+            }
+
+            $this->bodyStarted = true;
+            $content = $this->buffer;
+            $this->buffer = '';
+
+            return $content;
+        }
+    }
+
+    public function finish(): string
+    {
+        $content = $this->buffer;
+        $this->buffer = '';
+
+        if ($this->insideReasoning || preg_match('/\A\s*<think(?:\s[^>]*)?\z/i', $content) === 1) {
+            return '';
+        }
+
+        return $content;
+    }
+}

--- a/tests/Feature/AdminArticleAssistantTest.php
+++ b/tests/Feature/AdminArticleAssistantTest.php
@@ -23,6 +23,8 @@ use App\Support\GeoFlow\ApiKeyCrypto;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class AdminArticleAssistantTest extends TestCase
@@ -728,9 +730,10 @@ class AdminArticleAssistantTest extends TestCase
         $this->assertSame(0, (int) $model->fresh()->total_used);
     }
 
-    public function test_empty_ai_stream_does_not_consume_usage_or_knowledge_statistics(): void
+    #[DataProvider('emptyArticleStreams')]
+    public function test_empty_ai_stream_does_not_consume_usage_or_knowledge_statistics(string $raw): void
     {
-        MarkdownContentWriterAgent::fake([''])->preventStrayPrompts();
+        MarkdownContentWriterAgent::fake([$raw])->preventStrayPrompts();
 
         $admin = $this->createAdmin('assistant_empty_stream');
         $prompt = $this->createPrompt();
@@ -750,6 +753,72 @@ class AdminArticleAssistantTest extends TestCase
         $this->assertSame(0, (int) $model->fresh()->used_today);
         $this->assertSame(0, (int) $model->fresh()->total_used);
         $this->assertSame(0, (int) $knowledgeBase->fresh()->usage_count);
+    }
+
+    public static function emptyArticleStreams(): array
+    {
+        return [
+            'empty' => [''],
+            'reasoning only' => ['<think>Analyze only.</think>'],
+            'unfinished reasoning' => ['<think>Analyze without a final answer.'],
+            'unfinished opening tag' => ['<think'],
+        ];
+    }
+
+    #[DataProvider('articleStreamResponses')]
+    public function test_editor_filters_reasoning_before_streaming_each_delta(string $raw, string $expected): void
+    {
+        $admin = $this->createAdmin('assistant_reasoning_stream');
+        $prompt = $this->createPrompt();
+        $knowledgeBase = $this->createKnowledgeBase();
+        $model = $this->createModel(['api_url' => 'https://api.minimaxi.com/v1', 'model_id' => 'MiniMax-M2.5']);
+        $sse = '';
+        foreach (mb_str_split($raw) as $character) {
+            $sse .= 'data: '.json_encode(['choices' => [['delta' => ['content' => $character], 'finish_reason' => null]]])."\n\n";
+        }
+        $sse .= 'data: '.json_encode(['choices' => [['delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 20]])."\n\ndata: [DONE]\n\n";
+        Http::preventStrayRequests();
+        Http::fake(['https://api.minimaxi.com/v1/chat/completions' => Http::response($sse, 200, ['Content-Type' => 'text/event-stream'])]);
+
+        $response = $this->actingAs($admin, 'admin')->postJson(route('admin.articles.editor.generate'), [
+            'title' => '示例产品 榜单',
+            'knowledge_base_id' => $knowledgeBase->id,
+            'prompt_id' => $prompt->id,
+            'ai_model_id' => $model->id,
+        ]);
+        $response->assertOk();
+        $events = [];
+        foreach (explode("\n", $response->streamedContent()) as $line) {
+            if (str_starts_with($line, 'data: ') && ($event = json_decode(substr($line, 6), true))) {
+                $events[] = $event;
+            }
+        }
+        $deltas = array_values(array_filter($events, fn (array $event): bool => $event['type'] === 'text_delta'));
+        $replacement = array_values(array_filter($events, fn (array $event): bool => $event['type'] === 'article_content_replacement'));
+        $this->assertNotEmpty($deltas);
+        $this->assertSame($expected, implode('', array_column($deltas, 'delta')));
+        $this->assertCount(1, $replacement);
+        $this->assertSame($expected, $replacement[0]['content']);
+        $types = array_column($events, 'type');
+        $this->assertLessThan(array_search('text_end', $types), max(array_keys($types, 'text_delta')));
+        $this->assertSame(1, (int) $model->fresh()->total_used);
+        $this->assertSame(1, (int) $knowledgeBase->fresh()->usage_count);
+        $this->assertSame(20, AiModelUsageEvent::query()->sole()->output_tokens);
+        Http::assertSent(fn ($request): bool => ($request['reasoning_split'] ?? false) === true);
+    }
+
+    public static function articleStreamResponses(): array
+    {
+        $body = "## 中文正文\n\n内容完整。";
+
+        return [
+            'split tags' => [" \n<THINK>Let me write this carefully.</THINK>\n<think>Again.</think>\n".$body, $body],
+            'plain article' => [$body, $body],
+            'literal tags in code' => ["```html\n<think>示例</think>\n```", "```html\n<think>示例</think>\n```"],
+            'similar tag' => ['<thinking>中文正文</thinking>', '<thinking>中文正文</thinking>'],
+            'short literal' => ['<', '<'],
+            'partial ordinary tag' => ['<th', '<th'],
+        ];
     }
 
     public function test_ai_generation_rejects_non_content_prompt(): void

--- a/tests/Feature/WorkerExecutionServiceMaxTokensTest.php
+++ b/tests/Feature/WorkerExecutionServiceMaxTokensTest.php
@@ -7,8 +7,12 @@ use App\Data\Ai\AiExecutionContext;
 use App\Models\Admin;
 use App\Models\AiModel;
 use App\Models\AiModelUsageEvent;
+use App\Models\Article;
+use App\Models\Category;
 use App\Models\Task;
 use App\Models\TaskRun;
+use App\Models\Title;
+use App\Models\TitleLibrary;
 use App\Services\Admin\AdminAiModelMutationService;
 use App\Services\AiWorkspace\AiModelInvocationLock;
 use App\Services\GeoFlow\AiExecutionContextFactory;
@@ -23,6 +27,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Ai\Attributes\Timeout;
 use Laravel\Ai\Enums\Lab;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -198,6 +203,128 @@ class WorkerExecutionServiceMaxTokensTest extends TestCase
         $content = $this->generateContent($this->createChatModel(), '写一篇文章。');
 
         $this->assertSame('结论。Vitamin K2 与 K1 签证保留。', $content);
+    }
+
+    #[DataProvider('reasoningResponses')]
+    public function test_generate_content_removes_only_leading_reasoning(string $raw, string $expected): void
+    {
+        Http::preventStrayRequests();
+        Http::fake(['https://ai.test/v1/chat/completions' => Http::response($this->completion($raw))]);
+        $model = $this->createChatModel();
+
+        $content = $this->generateContent($model, '写一篇榜单文章。');
+
+        $this->assertSame($expected, $content);
+        $service = app(WorkerExecutionService::class);
+        $excerpt = new ReflectionMethod($service, 'buildExcerpt');
+        $this->assertSame($excerpt->invoke($service, $expected), $excerpt->invoke($service, $content));
+        $this->assertSame(1, (int) $model->fresh()->total_used);
+        $this->assertSame(20, AiModelUsageEvent::query()->sole()->output_tokens);
+    }
+
+    public static function reasoningResponses(): array
+    {
+        $body = "## 示例产品 榜单\n\n中文文章正文。";
+        $thought = 'Let me plan a product ranking article before writing the final answer.';
+        $raw = '<think>'.$thought."</think>\n\n".$body;
+
+        return [
+            'inline reasoning' => [$raw, $body],
+            'multiple blocks and whitespace' => [" \n<THINK>Analyze.</THINK>\n<think>Again.</think>\n".$body, $body],
+            'tag attributes' => ['<think mode="analysis">Analyze.</think>'.$body, $body],
+            'SSE text fallback' => ['data: '.json_encode(['choices' => [['delta' => ['content' => $raw]]]])."\n\ndata: [DONE]", $body],
+            'plain article' => [$body, $body],
+            'literal tags in article' => ["说明：<think>这是引用示例。</think>\n\n```html\n<think>示例</think>\n```", "说明：<think>这是引用示例。</think>\n\n```html\n<think>示例</think>\n```"],
+            'ordinary HTML' => ['<div>中文正文</div>', '<div>中文正文</div>'],
+            'similar tag' => ['<thinking>中文正文</thinking>', '<thinking>中文正文</thinking>'],
+            'short literal' => ['<', '<'],
+            'partial ordinary tag' => ['<th', '<th'],
+        ];
+    }
+
+    public function test_worker_saves_clean_article_excerpt_and_meta_description(): void
+    {
+        Http::preventStrayRequests();
+        Http::fake(['https://ai.test/v1/chat/completions' => Http::response($this->completion(
+            "<think>Let me plan the article before writing the final answer.</think>\n\n## 示例产品 榜单\n\n中文正文。",
+        ))]);
+        $model = $this->createChatModel();
+        $context = $this->executionContextForModel($model, 'worker-reasoning-persistence');
+        $library = TitleLibrary::query()->create(['name' => '榜单标题库']);
+        Title::query()->create(['library_id' => $library->id, 'title' => '示例产品 榜单', 'keyword' => '示例产品']);
+        Category::query()->create(['name' => '默认分类', 'slug' => 'reasoning-test-category']);
+        Task::query()->findOrFail($context->sourceId)->update([
+            'title_library_id' => $library->id,
+            'draft_limit' => 10,
+            'article_limit' => 10,
+        ]);
+
+        $result = app(WorkerExecutionService::class)->executeTask($context->sourceId, $context);
+
+        $article = Article::query()->findOrFail($result['article_id']);
+        $this->assertSame("## 示例产品 榜单\n\n中文正文。", $article->content);
+        $this->assertSame('示例产品 榜单 中文正文。', $article->excerpt);
+        $this->assertSame('示例产品 榜单 中文正文。', $article->meta_description);
+    }
+
+    #[DataProvider('reasoningOnlyResponses')]
+    public function test_generate_content_rejects_reasoning_without_an_article(string $raw): void
+    {
+        Http::fake(['https://ai.test/v1/chat/completions' => Http::response($this->completion($raw))]);
+        $model = $this->createChatModel(['daily_limit' => 1]);
+
+        try {
+            $this->generateContent($model, '写一篇文章。');
+            $this->fail('Expected reasoning-only output to fail.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('AI返回空正文', $exception->getMessage());
+        }
+
+        $this->assertSame(0, (int) $model->fresh()->used_today);
+        $this->assertSame(0, (int) $model->fresh()->total_used);
+    }
+
+    public static function reasoningOnlyResponses(): array
+    {
+        return [
+            'closed' => ['<think>Analyze only.</think>'],
+            'unclosed' => ['<think>Analyze without a final answer.'],
+            'incomplete opening tag' => ['<think'],
+        ];
+    }
+
+    #[DataProvider('miniMaxEndpoints')]
+    public function test_reasoning_split_is_limited_to_official_minimax_article_requests(string $url, string $modelId, bool $split): void
+    {
+        Http::preventStrayRequests();
+        Http::fake(['*' => Http::response($this->completion('中文正文。'))]);
+        $model = $this->createChatModel(['api_url' => $url, 'model_id' => $modelId, 'max_tokens' => 8192]);
+
+        $this->assertSame('中文正文。', $this->generateContent($model, '写一篇文章。'));
+
+        Http::assertSent(function ($request) use ($split): bool {
+            $this->assertSame(8192, $request['max_tokens']);
+            if ($split) {
+                $this->assertTrue($request['reasoning_split'] ?? false);
+            } else {
+                $this->assertArrayNotHasKey('reasoning_split', $request->data());
+            }
+
+            return true;
+        });
+        Http::assertSentCount(1);
+    }
+
+    public static function miniMaxEndpoints(): array
+    {
+        return [
+            'China' => ['https://api.minimaxi.com/v1', 'MiniMax-M2.5', true],
+            'international' => ['https://api.minimax.io/v1', 'MiniMax-M2.1', true],
+            'China current' => ['https://api.minimax.cn/v1', 'MiniMax-M3', true],
+            'proxy' => ['https://ai.test/v1', 'MiniMax-M2.5', false],
+            'lookalike domain' => ['https://api.minimaxi.com.example.test/v1', 'MiniMax-M2.5', false],
+            'other model' => ['https://ai.test/v1', 'test-chat-model', false],
+        ];
     }
 
     public function test_generate_content_releases_usage_for_an_empty_response(): void


### PR DESCRIPTION
## 变更说明

MiniMax 将 `<think>...</think>` 放入响应正文时，文章开头、摘要和 SEO 描述会混入思考文本。对官方 MiniMax 接口开启 `reasoning_split`，并在文章生成服务中统一过滤开头的思考区块，覆盖批量生成和编辑器流式输出。

过滤器处理跨片段标签、连续区块和未完成思考，保留正文及代码示例中的字面标签；只有思考内容的响应沿用空正文与额度释放逻辑。第三方网关和其他模型保持原有请求参数。已有文章数据不作自动修改。

## 验证

- 最新 main 的隔离工作区：105 项相关测试通过，473 条断言。
- 覆盖逐字符 SSE 拆包、普通正文、字面标签、空结果用量，以及正文/摘要/SEO 描述保存。
- PHP 格式检查、生产资源构建、git diff --check 通过。
- 测试数据使用通用示例，未包含客户截图或凭据。
