### PR TITLE
docs: 同步 3.1.0 正式发布与双架构验收结果

### DIFF
--- a/docs/blue-green-deployment-usage.md
+++ b/docs/blue-green-deployment-usage.md
@@ -4,9 +4,9 @@
 
 面向站点管理员和服务器管理员，涵盖首次安装、旧站接管、后台升级、自动迁移、备份和恢复。
 
-本文依据 [GEOFlow PR #122](https://github.com/yaojingang/GEOFlow/pull/122) 与 [updater PR #16](https://github.com/yaojingang/geoflow-updater/pull/16) 合并后的实现编写。后续恢复修复及完整双架构结果见[主机验收记录](reports/2026-09-09-blue-green-host-acceptance.md)。
+本文依据 [GEOFlow PR #122](https://github.com/yaojingang/GEOFlow/pull/122) 与 [updater PR #16](https://github.com/yaojingang/geoflow-updater/pull/16) 合并后的实现编写。历史候选及恢复修复见[主机验收记录](reports/2026-09-09-blue-green-host-acceptance.md)，正式版本的 [11 项双架构验收](https://github.com/yaojingang/geoflow-updater/actions/runs/34324570077)全部通过。
 
-> **版本前提：** 本教程的新流程要求正式发布的 [GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0)、[Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0)、配套镜像和已签名升级计划。确认两个 Release 和签名更新源均已公开后执行；源码分支的版本号本身不代表发布完成。旧站首次升级路径见 [3.1 升级说明](deployment/GEOFLOW_V3_1_UPGRADE.md)。
+> **正式版本，2026 年 9 月 9 日：** [GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0) 与 [Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0) 已正式发布，配套双架构镜像和签名更新源已公开，更新序列为 `3`。本次升级采用 `maintenance`，3.0.0 到 3.1.0 升级及首次蓝绿布局转换均需维护窗口。旧站请按 [3.1 升级说明](deployment/GEOFLOW_V3_1_UPGRADE.md)操作。
 
 ## 1. 选择使用路径
 
@@ -57,7 +57,7 @@ systemctl --version
 
 ### 3.2 下载并校验
 
-从 [updater Releases](https://github.com/yaojingang/geoflow-updater/releases) 选择明确包含本轮功能的正式版本，下载对应架构的压缩包与 `checksums.txt`，放入专用目录。
+从 [Updater v0.4.0 正式发布页](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0)下载对应架构的压缩包与 `checksums.txt`，放入专用目录。
 
 本轮配套版本为 `0.4.0`，命令需要已安装 GitHub CLI：
 
@@ -405,7 +405,7 @@ updater 启动及后台检查会根据持久化记录处理被中断的操作。
 
 普通站点管理员按上述流程选择和确认计划。在线兼容性由发布者声明，并通过对应候选版本的验证。
 
-**2026 年 9 月 9 日进展：** Updater `0.4.0-rc.4` 配套签名候选已完成原生 amd64、arm64 的安装、完整升级恢复、中断恢复和在线机制验收，全部通过。候选身份、逐项结果及修复 PR 见[验收记录](reports/2026-09-09-blue-green-host-acceptance.md)。技术验收与正式发布分别记录，安装时仍需满足[版本前提](#geoflow-蓝绿部署与自动迁移使用教程)。
+**2026 年 9 月 9 日正式验收：** 配套 Updater `0.4.0` 的[正式候选](https://github.com/yaojingang/geoflow-updater/actions/runs/34322064152)完成了原生 amd64、arm64 的容器检查、首次安装、升级恢复、在线机制和同版本接管转换验收，[11 个任务全部通过](https://github.com/yaojingang/geoflow-updater/actions/runs/34324570077)。[配套发布](https://github.com/yaojingang/geoflow-updater/actions/runs/34342933580)与[更新源部署](https://github.com/yaojingang/geoflow-updater/actions/runs/34343146320)均已完成。早期 `0.4.0-rc.4` 的结果保留在[历史验收记录](reports/2026-09-09-blue-green-host-acceptance.md)。
 
 - `deployment/upgrade-plan.json` 固定迁移文件摘要。新增迁移后更新并审阅清单，再运行 `python3 deployment/generate-upgrade-plan.py --check`。
 - schema 3 发布清单将完整计划纳入 TUF 签名目标 `releases/<version>/upgrade-plan.json`。维护计划要求协议至少为 3，在线计划至少为 4；应用计划与预检摘要各自的 schema 版本需分别理解。

--- a/docs/blue-green-deployment-usage_en.md
+++ b/docs/blue-green-deployment-usage_en.md
@@ -4,9 +4,9 @@
 
 For site and server administrators. This tutorial covers fresh installation, enrollment, updates through the admin UI or CLI, automatic migrations, backups, and recovery.
 
-It follows the implementation merged in [GEOFlow PR #122](https://github.com/yaojingang/GEOFlow/pull/122) and [updater PR #16](https://github.com/yaojingang/geoflow-updater/pull/16). Subsequent recovery fixes and complete dual-architecture results are recorded in the [host acceptance report](reports/2026-09-09-blue-green-host-acceptance_en.md).
+It follows the implementation merged in [GEOFlow PR #122](https://github.com/yaojingang/GEOFlow/pull/122) and [updater PR #16](https://github.com/yaojingang/geoflow-updater/pull/16). Historical candidates and recovery fixes are recorded in the [host acceptance report](reports/2026-09-09-blue-green-host-acceptance_en.md). All [11 dual-architecture acceptance jobs](https://github.com/yaojingang/geoflow-updater/actions/runs/34324570077) for the official version passed.
 
-> **Release prerequisites:** This workflow requires the official [GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0) and [Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0), matching images and a signed upgrade plan. Proceed after both releases and the signed update source are public; a source-branch version alone does not establish publication. See the [3.1 upgrade instructions](deployment/GEOFLOW_V3_1_UPGRADE_en.md) for existing sites.
+> **Official release, September 9, 2026:** [GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0) and [Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0) are published, with matching dual-architecture images and a public signed update source at release sequence `3`. This release uses `maintenance`; both the 3.0.0 to 3.1.0 upgrade and initial blue/green conversion require a maintenance window. Existing sites should follow the [3.1 upgrade instructions](deployment/GEOFLOW_V3_1_UPGRADE_en.md).
 
 ## 1. Choose your path
 
@@ -57,7 +57,7 @@ systemctl --version
 
 ### 3.2 Download and verify
 
-Choose an official release that explicitly includes this workflow from [updater Releases](https://github.com/yaojingang/geoflow-updater/releases). Download the archive for your architecture and `checksums.txt` into a dedicated directory.
+Download the archive for your architecture and `checksums.txt` from the [Updater v0.4.0 release](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0) into a dedicated directory.
 
 The matching updater version for this release is `0.4.0`. These commands require GitHub CLI:
 
@@ -405,7 +405,7 @@ Before sharing diagnostics, remove passwords, tokens, authorization URIs, and pr
 
 Site administrators select and confirm plans through the workflow above. Publishers declare online compatibility and validate it against the corresponding candidate release.
 
-**September 9, 2026 update:** The signed candidate paired with Updater `0.4.0-rc.4` passed installation, full upgrade/restoration, interruption recovery and online-mechanism acceptance on native amd64 and arm64. See the [acceptance report](reports/2026-09-09-blue-green-host-acceptance_en.md) for candidate identity, individual results and fix PRs. Technical acceptance and official publication have separate records; installation still requires the [release prerequisites](#geoflow-bluegreen-deployment-and-automatic-migration-tutorial).
+**Official acceptance, September 9, 2026:** The [official candidate](https://github.com/yaojingang/geoflow-updater/actions/runs/34322064152) paired with Updater `0.4.0` passed native amd64 and arm64 container checks, fresh installation, upgrade/restoration, online-mechanism and same-version enrollment/conversion acceptance: [all 11 jobs passed](https://github.com/yaojingang/geoflow-updater/actions/runs/34324570077). [Paired publication](https://github.com/yaojingang/geoflow-updater/actions/runs/34342933580) and [update-source deployment](https://github.com/yaojingang/geoflow-updater/actions/runs/34343146320) are complete. Earlier `0.4.0-rc.4` results remain in the [historical acceptance report](reports/2026-09-09-blue-green-host-acceptance_en.md).
 
 - `deployment/upgrade-plan.json` pins migration-file digests. After adding migrations, update and review the manifest, then run `python3 deployment/generate-upgrade-plan.py --check`.
 - A schema 3 release manifest includes the complete plan as the TUF-signed target `releases/<version>/upgrade-plan.json`. Maintenance plans require protocol 3 or later; online plans require protocol 4 or later. Application-plan and preview schemas have their own versions.

--- a/docs/deployment/GEOFLOW_V3_1_RELEASE.md
+++ b/docs/deployment/GEOFLOW_V3_1_RELEASE.md
@@ -1,6 +1,14 @@
 # GEOFlow v3.1.0 配套发布记录与流程
 
-本轮版本：GEOFlow `3.1.0`、Updater `0.4.0`、签名更新序列 `3`。当前公开基线为 GEOFlow `3.0.0`、Updater `0.3.0`、序列 `2`；开始发布时重新核对远端状态，序列必须递增。
+本轮版本：GEOFlow `3.1.0`、Updater `0.4.0`、签名更新序列 `3`。发布前基线为 GEOFlow `3.0.0`、Updater `0.3.0`、序列 `2`；开始发布时重新核对远端状态，序列必须递增。
+
+## 正式发布结果
+
+2026 年 9 月 9 日，[GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0) 与 [Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0) 均已正式发布。两个标签使用维护者的现有 GPG 密钥签署，发布资产已回读核验。
+
+- Core 固定提交：`6c963783bbf49f0b5ec9d0121a924ee54005b60d`；Updater 固定提交：`51a0a4b3bd00c67eb719c076e68ba4e35aec071a`。
+- [候选 34322064152](https://github.com/yaojingang/geoflow-updater/actions/runs/34322064152)对应的[验收 34324570077](https://github.com/yaojingang/geoflow-updater/actions/runs/34324570077)共 11 个任务，全部通过。
+- [配套发布](https://github.com/yaojingang/geoflow-updater/actions/runs/34342933580)及 [Pages 部署](https://github.com/yaojingang/geoflow-updater/actions/runs/34343146320)成功，公共更新源为 Core `3.1.0`、序列 `3`、维护模式。
 
 ## 固定发布范围
 
@@ -17,7 +25,7 @@
 4. 从固定 Updater main 触发 `release-candidate.yml`，输入 `updater_version=0.4.0`、Core 最终 SHA、`geoflow_version=3.1.0` 和 `release_sequence=3`。记录候选 run ID，下载候选并核对版本、源码、档案、镜像、版本文档和升级计划摘要。
 5. 运行 `planned-acceptance.yml`，两种原生架构分别完成容器检查、首次安装、旧版升级恢复、在线机制和同版本接管转换演练。审阅汇总证据后，由发布操作员、安全审阅者和产品负责人具名批准该候选；将完整 JSON 写入受保护环境并记录 SHA-256。以前的 RC 记录作为历史证据保留。
 6. 从 Core 最终 SHA 生成并核对三个资产，创建签名标签 `v3.1.0` 和 Draft Release，重新下载比较字节与校验和。全部门槛通过后公开 Core，暂不提升 Latest，验证不可变 Release 及资产证明。
-7. 按 [Updater 发布手册](https://github.com/yaojingang/geoflow-updater/blob/main/docs/release-runbook.md)触发 `release.yml`，使用同一候选和已批准证据，`superadmin_risk_waiver=false`。等待发布工作流和其触发的 Pages 工作流均成功，回读公共 TUF 签名链、Core `3.1.0`／序列 `3`／源码及镜像摘要，以及 Updater 两架构资产和发布授权。
+7. 由具名发布身份在候选 Updater 源码提交上创建并验证签名标签 `v0.4.0`，保留版本标签保护。按 [Updater 发布手册](https://github.com/yaojingang/geoflow-updater/blob/main/docs/release-runbook.md)触发 `release.yml`，使用同一候选和已批准证据，`superadmin_risk_waiver=false`。等待发布工作流和其触发的 Pages 工作流均成功，回读公共 TUF 签名链、Core `3.1.0`／序列 `3`／源码及镜像摘要，以及 Updater 两架构资产和发布授权。
 8. 确认配套内容都可用后，将 Updater `v0.4.0` 和 Core `v3.1.0` 依次提升为 Latest；回读两处 Latest 下载入口、Core 版本文档和 Updater bootstrap。同步中英文教程与 Wiki 的最终结果。
 
 完成后按原状态恢复两个元数据刷新工作流。若发布中止且签名目标尚未提交，核对旧稳定通道后恢复；若新 TUF 已提交，先用同一候选安全续跑并闭合资产与 Pages 状态，再恢复刷新。记录任何仍未完成的环节及停用状态。

--- a/docs/deployment/GEOFLOW_V3_1_UPGRADE.md
+++ b/docs/deployment/GEOFLOW_V3_1_UPGRADE.md
@@ -2,7 +2,7 @@
 
 简体中文 | [English](GEOFLOW_V3_1_UPGRADE_en.md)
 
-目标版本为 GEOFlow `v3.1.0` 与 GEOFlow Updater `v0.4.0`。执行前确认两个正式 Release、配套镜像和签名更新源均已公开；源码分支中的版本号本身不代表发布完成。
+[GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0) 与 [GEOFlow Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0) 已于 2026 年 9 月 9 日正式发布。配套双架构镜像和签名更新源已公开，本次更新序列为 `3`，升级策略为 `maintenance`。
 
 ## 选择升级路径
 

--- a/docs/deployment/GEOFLOW_V3_1_UPGRADE_en.md
+++ b/docs/deployment/GEOFLOW_V3_1_UPGRADE_en.md
@@ -2,7 +2,7 @@
 
 [简体中文](GEOFLOW_V3_1_UPGRADE.md) | English
 
-The target pair is GEOFlow `v3.1.0` and GEOFlow Updater `v0.4.0`. Proceed after both official releases, matching images and the signed update source are public. A version number on a source branch alone does not establish publication.
+[GEOFlow v3.1.0](https://github.com/yaojingang/GEOFlow/releases/tag/v3.1.0) and [GEOFlow Updater v0.4.0](https://github.com/yaojingang/geoflow-updater/releases/tag/v0.4.0) were officially published on September 9, 2026. Matching dual-architecture images and the signed update source are public. This release uses sequence `3` and the `maintenance` strategy.
 
 ## Choose an upgrade path
 


### PR DESCRIPTION
## 变更说明 / Summary

GEOFlow v3.1.0 与 Updater v0.4.0 已正式发布。同步中英文蓝绿部署教程和 3.1 升级说明，直接链接 Updater 正式下载页，加入最终 11 项验收、配套发布和更新源部署记录，并保留本次升级与首次布局转换的维护窗口要求。发布手册补充由指定维护者创建配套签名标签的步骤。

## 验证 / Verification

- 两个不可变 Release、签名标签、八个下载资产、构件证明、bootstrap 和公共 TUF 签名链均已核对；七个签名目标与验收候选逐字节一致。
- 应用与入口镜像的版本标签及 latest 标签均匹配候选摘要，包含原生 amd64 和 arm64；11 项候选验收及配套发布、Pages 工作流成功。
- 四份教程的本地链接和标题锚点、Wiki 镜像转换、中英文新增段落标点及 `git diff --check` 通过。文档状态更新不改变应用行为，无需新增运行时测试；仓库 CI 以本 PR 最新提交为准。

## CLA 声明 / CLA declaration

GitHub 维护者：`yaojingang`。本次为维护者请求的项目文档更新，未引入第三方材料；不代填法定身份或新增 CLA 签署声明。

## 检查清单 / Checklist

- [x] 本次提交不包含新增第三方材料。
- [x] 没有提交凭据、客户数据或其他敏感信息。
- [x] 已说明无需新增运行时测试的原因。
