### PR TITLE
fix: 整理账户页表单与权限布局

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -315,13 +315,26 @@ html[data-gf-sidebar-resizing] body { cursor: col-resize; user-select: none; }
 .gf-field > small { color: var(--gf-gray-400); font-size: 10px; }
 .gf-settings-actions { align-items: center; background: var(--gf-gray-50); border-top: 1px solid var(--gf-gray-200); display: flex; gap: 10px; justify-content: flex-end; padding: 14px 24px; }
 .gf-settings-actions > span { color: var(--gf-gray-400); font-size: 11px; margin-right: auto; }
-.gf-account-page { align-items: start; display: grid; gap: 18px; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); }
-.gf-account-page__aside { display: grid; gap: 18px; }
+.gf-account-page { align-items: start; display: grid; gap: 24px; grid-template-columns: minmax(0, 1fr) 320px; }
+.gf-account-page__main { display: grid; gap: 24px; min-width: 0; }
+.gf-account-page__aside { min-width: 0; }
+.gf-account-page .gf-settings-panel__header { padding: 20px 24px; }
+.gf-account-page .gf-settings-panel__header h2 { font-size: 16px; }
+.gf-account-page .gf-settings-panel__header p { font-size: 13px; line-height: 1.6; }
+.gf-account-page__fields { display: grid; gap: 18px; grid-template-columns: repeat(2, minmax(0, 1fr)); padding: 22px 24px; }
+.gf-account-page__field--full { grid-column: 1 / -1; }
+.gf-account-page .gf-field { min-width: 0; }
+.gf-account-page .gf-field > span { font-size: 13px; }
+.gf-account-page .gf-settings-actions { flex-wrap: wrap; gap: 12px; }
+.gf-account-page .gf-settings-actions > span { color: var(--gf-gray-500); flex: 1 1 180px; font-size: 12px; }
+.gf-account-page .gf-settings-actions .gf-button { flex: 0 0 auto; white-space: nowrap; }
+.gf-account-page .gf-button svg { flex-shrink: 0; }
+.gf-account-page__aside .gf-settings-actions { align-items: flex-start; flex-direction: column; }
+.gf-account-page__aside .gf-settings-actions > span { flex: auto; }
 .gf-permission-list { display: grid; gap: 12px; list-style: none; margin: 0; padding: 18px 22px 22px; }
 .gf-permission-list li { align-items: flex-start; color: var(--gf-gray-600); display: flex; gap: 10px; }
 .gf-permission-list li > span { align-items: center; background: var(--gf-emerald-50); border-radius: 999px; color: var(--gf-emerald-600); display: inline-flex; flex: 0 0 24px; height: 24px; justify-content: center; width: 24px; }
 .gf-permission-list svg { height: 14px; width: 14px; }
-.gf-password-fields { display: grid; gap: 16px; padding: 22px 24px; }
 
 .gf-modal-backdrop { align-items: center; background: rgba(15, 23, 42, .48); display: flex; inset: 0; justify-content: center; opacity: 0; overscroll-behavior: contain; padding: 24px; position: fixed; transition: opacity 160ms ease-out; z-index: 120; }
 .gf-modal-backdrop.is-open { opacity: 1; }
@@ -944,6 +957,11 @@ details.gf-ai-trace-event[open] .gf-ai-trace-event__chevron { transform: rotate(
     .gf-settings-actions { flex-wrap: wrap; padding: 14px 18px; }
     .gf-settings-actions > span { flex-basis: 100%; }
     .gf-settings-actions .gf-button { flex: 1; }
+    .gf-account-page, .gf-account-page__main { gap: 18px; }
+    .gf-account-page .gf-settings-panel__header { padding: 18px; }
+    .gf-account-page__fields { grid-template-columns: minmax(0, 1fr); padding: 18px; }
+    .gf-account-page .gf-settings-actions > span { flex-basis: 100%; }
+    .gf-account-page .gf-settings-actions .gf-button { width: 100%; }
     .gf-modal-backdrop { align-items: center; padding: 16px; }
     .gf-modal { max-height: calc(100dvh - 32px); }
     .gf-community-dialog { gap: 20px; grid-template-columns: 1fr; }

--- a/resources/views/admin/account/show.blade.php
+++ b/resources/views/admin/account/show.blade.php
@@ -10,49 +10,90 @@
 </div>
 
 <div class="gf-account-page">
-    <section class="gf-settings-panel">
-        <form method="POST" action="{{ \App\Support\AdminWeb::routePath('admin.account.profile.update') }}" data-admin-unsaved>
-            @csrf
-            @method('PUT')
-            <input type="hidden" name="profile_version" value="{{ \App\Support\AdminAccountProfileVersion::for($admin) }}">
-            <div class="gf-form-section">
-                <div class="gf-form-section__intro"><h2>{{ __('admin.account.profile_title') }}</h2><p>{{ __('admin.account.profile_description') }}</p></div>
-                <div class="gf-form-section__fields">
-                    <label class="gf-field"><span>{{ __('admin.account.username') }}</span><input type="text" value="{{ $admin->username }}" disabled><small>{{ __('admin.account.role') }} · {{ $admin->isSuperAdmin() ? __('admin.header.super_admin') : __('admin.header.admin') }}</small></label>
-                    <label class="gf-field"><span>{{ __('admin.account.display_name') }}</span><input type="text" name="display_name" value="{{ old('display_name', $admin->display_name) }}" maxlength="100" autocomplete="name"></label>
-                    <label class="gf-field"><span>{{ __('admin.account.email') }}</span><input type="email" name="email" value="{{ old('email', $admin->email) }}" maxlength="100" autocomplete="email"></label>
+    <div class="gf-account-page__main">
+        <section class="gf-settings-panel" aria-labelledby="account-profile-title">
+            <header class="gf-settings-panel__header">
+                <div>
+                    <h2 id="account-profile-title">{{ __('admin.account.profile_title') }}</h2>
+                    <p>{{ __('admin.account.profile_description') }}</p>
                 </div>
-            </div>
-            <footer class="gf-settings-actions"><span>{{ __('admin.account.last_login') }} · {{ $admin->last_login?->format('Y-m-d H:i') ?: __('admin.account.never') }}</span><button class="gf-button gf-button--primary" type="submit"><i data-lucide="save"></i>{{ __('admin.account.save_profile') }}</button></footer>
-        </form>
-    </section>
+            </header>
+            <form method="POST" action="{{ \App\Support\AdminWeb::routePath('admin.account.profile.update') }}" data-admin-unsaved>
+                @csrf
+                @method('PUT')
+                <input type="hidden" name="profile_version" value="{{ \App\Support\AdminAccountProfileVersion::for($admin) }}">
+                <div class="gf-account-page__fields">
+                    <label class="gf-field gf-account-page__field--full">
+                        <span>{{ __('admin.account.username') }}</span>
+                        <input type="text" value="{{ $admin->username }}" disabled>
+                    </label>
+                    <label class="gf-field">
+                        <span>{{ __('admin.account.display_name') }}</span>
+                        <input type="text" name="display_name" value="{{ old('display_name', $admin->display_name) }}" maxlength="100" autocomplete="name">
+                    </label>
+                    <label class="gf-field">
+                        <span>{{ __('admin.account.email') }}</span>
+                        <input type="email" name="email" value="{{ old('email', $admin->email) }}" maxlength="100" autocomplete="email">
+                    </label>
+                </div>
+                <footer class="gf-settings-actions">
+                    <span>{{ __('admin.account.last_login') }} · {{ $admin->last_login?->format('Y-m-d H:i') ?: __('admin.account.never') }}</span>
+                    <button class="gf-button gf-button--primary" type="submit"><i data-lucide="save"></i>{{ __('admin.account.save_profile') }}</button>
+                </footer>
+            </form>
+        </section>
+
+        <section class="gf-settings-panel" aria-labelledby="account-password-title">
+            <header class="gf-settings-panel__header">
+                <div>
+                    <h2 id="account-password-title">{{ __('admin.account.password_title') }}</h2>
+                    <p>{{ __('admin.account.password_description') }}</p>
+                </div>
+            </header>
+            <form method="POST" action="{{ \App\Support\AdminWeb::routePath('admin.account.password.update') }}" data-admin-unsaved>
+                @csrf
+                @method('PUT')
+                <div class="gf-account-page__fields">
+                    <label class="gf-field gf-account-page__field--full">
+                        <span>{{ __('admin.account.current_password') }}</span>
+                        <input type="password" name="current_password" required autocomplete="current-password">
+                    </label>
+                    <label class="gf-field">
+                        <span>{{ __('admin.account.new_password') }}</span>
+                        <input type="password" name="password" required minlength="8" autocomplete="new-password">
+                    </label>
+                    <label class="gf-field">
+                        <span>{{ __('admin.account.confirm_password') }}</span>
+                        <input type="password" name="password_confirmation" required minlength="8" autocomplete="new-password">
+                    </label>
+                </div>
+                <footer class="gf-settings-actions">
+                    <span>{{ __('admin.account.security_hint') }}</span>
+                    <button class="gf-button" type="submit"><i data-lucide="key-round"></i>{{ __('admin.account.update_password') }}</button>
+                </footer>
+            </form>
+        </section>
+    </div>
 
     <aside class="gf-account-page__aside">
-        <section class="gf-settings-panel">
-            <header class="gf-settings-panel__header"><div><h2>{{ __('admin.account.permissions_title') }}</h2><p>{{ __('admin.account.role') }} · {{ $admin->isSuperAdmin() ? __('admin.header.super_admin') : __('admin.header.admin') }}</p></div></header>
+        <section class="gf-settings-panel" aria-labelledby="account-permissions-title">
+            <header class="gf-settings-panel__header">
+                <div>
+                    <h2 id="account-permissions-title">{{ __('admin.account.permissions_title') }}</h2>
+                    <p>{{ __('admin.account.role') }} · {{ $admin->isSuperAdmin() ? __('admin.header.super_admin') : __('admin.header.admin') }}</p>
+                </div>
+            </header>
             <ul class="gf-permission-list">
                 <li><span><i data-lucide="circle-check"></i></span>{{ __('admin.account.permission_business') }}</li>
                 <li><span><i data-lucide="circle-check"></i></span>{{ __('admin.account.permission_settings') }}</li>
-                @if ($admin->isSuperAdmin())<li><span><i data-lucide="circle-check"></i></span>{{ __('admin.account.permission_protected') }}</li>@endif
+                @if ($admin->isSuperAdmin())
+                    <li><span><i data-lucide="circle-check"></i></span>{{ __('admin.account.permission_protected') }}</li>
+                @endif
             </ul>
             <footer class="gf-settings-actions">
                 <span>{{ __('admin.browser_operations.clients.account_hint') }}</span>
                 <a class="gf-button" href="{{ route('admin.account.browser-clients.index') }}"><i data-lucide="monitor-smartphone"></i>{{ __('admin.browser_operations.clients.manage') }}</a>
             </footer>
-        </section>
-
-        <section class="gf-settings-panel">
-            <header class="gf-settings-panel__header"><div><h2>{{ __('admin.account.password_title') }}</h2><p>{{ __('admin.account.password_description') }}</p></div></header>
-            <form method="POST" action="{{ \App\Support\AdminWeb::routePath('admin.account.password.update') }}" data-admin-unsaved>
-                @csrf
-                @method('PUT')
-                <div class="gf-password-fields">
-                    <label class="gf-field"><span>{{ __('admin.account.current_password') }}</span><input type="password" name="current_password" required autocomplete="current-password"></label>
-                    <label class="gf-field"><span>{{ __('admin.account.new_password') }}</span><input type="password" name="password" required minlength="8" autocomplete="new-password"></label>
-                    <label class="gf-field"><span>{{ __('admin.account.confirm_password') }}</span><input type="password" name="password_confirmation" required minlength="8" autocomplete="new-password"></label>
-                </div>
-                <footer class="gf-settings-actions"><span>{{ __('admin.account.security_hint') }}</span><button class="gf-button" type="submit"><i data-lucide="key-round"></i>{{ __('admin.account.update_password') }}</button></footer>
-            </form>
         </section>
     </aside>
 </div>


### PR DESCRIPTION
## 变更说明 / Summary

账户页原先将资料表单放在宽主列，密码表单挤在权限卡片下方，右侧操作按钮因说明文字占位而换行。本次将资料与密码表单统一放在主列，权限信息独立展示，并统一标题、字段与操作区间距。桌面表单按两列组织相关字段，窄屏改为单列和全宽按钮。

修改范围为账户页 Blade 模板及其专属样式，共两个文件。表单提交地址、CSRF、资料版本校验、密码验证和权限判断沿用现有实现。

## 验证 / Verification

- 独立工作区执行账户、后台整页、后台框架及网站设置相关测试，46 项通过。
- `npm run build`、`vendor/bin/pint --dirty --format agent`、`composer validate --strict`、`git diff --check` 通过。
- 使用真实模板和测试数据完成 1440px 桌面、375px 窄屏预览及七种语言按钮检查；两个原先换行的操作按钮从约 47px 恢复为 40px 单行高度。
- 用户已确认本地效果。本次为布局调整，未新增业务分支，沿用现有功能测试；未通过浏览器提交真实账户资料或密码。

## CLA 声明 / CLA declaration

GitHub 维护者：`yaojingang`。本次为维护者请求的账户页排版调整，未引入第三方材料；不代填法定身份或新增 CLA 签署声明。

## 检查清单 / Checklist

- [x] 本次提交不包含新增第三方材料。
- [x] 没有提交凭据、客户数据或其他敏感信息。
- [x] 已说明无需新增业务测试的原因。
