### PR TITLE
fix: align local Docker gateway defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ENV=production
 # 留空则由 Docker 入口执行 key:generate 写入；勿向容器注入「空」的 APP_KEY 环境变量，否则无法写入有效密钥。
 APP_KEY=
 APP_DEBUG=false
-APP_URL=https://your-domain.com
+APP_URL=http://localhost:18080
 SITE_URL=
 ASSET_URL=
 
@@ -42,7 +42,7 @@ GEOFLOW_AI_WORKSPACE_REQUIRE_VERIFIED_MODEL=true
 
 # 托管渠道站点默认关闭。启用前需完成泛 DNS、通配符 TLS、可信代理和 Nginx 三入口配置。
 GEOFLOW_HOSTED_SITES_ENABLED=false
-GEOFLOW_PRIMARY_HOSTS=your-domain.com,www.your-domain.com
+GEOFLOW_PRIMARY_HOSTS=localhost
 GEOFLOW_HOSTED_SITE_ROOT_DOMAINS=
 # Nginx 三入口使用单个主站域名、可选空格分隔别名，以及单个托管根域。
 GEOFLOW_NGINX_PRIMARY_HOST=your-domain.com

--- a/tests/Unit/InfrastructureGatewayConfigurationTest.php
+++ b/tests/Unit/InfrastructureGatewayConfigurationTest.php
@@ -22,6 +22,31 @@ final class InfrastructureGatewayConfigurationTest extends TestCase
         self::assertStringNotContainsString("\n  horizon:\n", $compose);
     }
 
+    public function test_fresh_checkout_configuration_matches_the_documented_local_gateway(): void
+    {
+        $localEnvironment = $this->read('.env.example');
+        $productionEnvironment = $this->read('.env.prod.example');
+        $readme = $this->read('README.md');
+
+        self::assertStringContainsString('APP_URL=http://localhost:18080', $localEnvironment);
+        self::assertStringContainsString('SITE_URL="${APP_URL}"', $localEnvironment);
+        self::assertStringContainsString('APP_PORT=18080', $localEnvironment);
+        self::assertStringContainsString('ADMIN_BASE_PATH=geo_admin', $localEnvironment);
+        self::assertStringContainsString('GEOFLOW_PRIMARY_HOSTS=localhost', $localEnvironment);
+        self::assertStringContainsString('REVERB_HOST=localhost', $localEnvironment);
+        self::assertStringContainsString('REVERB_PORT=18080', $localEnvironment);
+        self::assertStringContainsString('REVERB_SCHEME=http', $localEnvironment);
+        self::assertStringContainsString('REVERB_ALLOWED_ORIGINS=localhost', $localEnvironment);
+        self::assertStringContainsString('http://localhost:18080', $readme);
+        self::assertStringContainsString('http://localhost:18080/geo_admin/login', $readme);
+
+        self::assertStringContainsString('APP_URL=https://your-domain.com', $productionEnvironment);
+        self::assertStringContainsString(
+            'GEOFLOW_PRIMARY_HOSTS=your-domain.com,www.your-domain.com',
+            $productionEnvironment,
+        );
+    }
+
     public function test_local_nginx_serves_fingerprinted_assets_and_same_origin_reverb(): void
     {
         $nginx = $this->read('docker/nginx/local.conf');


### PR DESCRIPTION
## Summary
- Fixes #125 by aligning the local example environment with the documented `http://localhost:18080` gateway.
- Restricts the local primary host allowlist to `localhost` so the frontend and `/geo_admin/login` are reachable after copying `.env.example`.
- Adds a configuration contract test that keeps local, README, Reverb, and production defaults aligned.

## Verification
- `vendor/bin/pint tests/Unit/InfrastructureGatewayConfigurationTest.php --format agent`
- `php artisan test --compact tests/Unit/InfrastructureGatewayConfigurationTest.php tests/Feature/HostedSites/HostedSiteHostBoundaryTest.php tests/Feature/AdminLoginPageTest.php`
- `docker compose config --quiet`
- Clean worktree verification with the staged patch: 6 tests passed (81 assertions).

Closes #125.