### PR TITLE
fix: reject unsafe CTA target URLs

### DIFF
--- a/app/Http/Controllers/Admin/SiteSettingsController.php
+++ b/app/Http/Controllers/Admin/SiteSettingsController.php
@@ -9,6 +9,7 @@ use App\Services\Admin\SiteThemeReplicationService;
 use App\Support\AdminBasePathManager;
 use App\Support\AdminWeb;
 use App\Support\Site\ArticleTextAdPicker;
+use App\Support\Site\CtaTargetUrlNormalizer;
 use App\Support\Site\HomepageModuleBuilder;
 use App\Support\Site\SiteSettingsBag;
 use App\Support\Site\SiteThemeCatalog;
@@ -378,11 +379,12 @@ class SiteSettingsController extends Controller
             $title = trim((string) ($postedAd['title'] ?? ''));
             $copy = trim((string) ($postedAd['copy'] ?? ''));
             $buttonText = trim((string) ($postedAd['button_text'] ?? ''));
-            $buttonUrl = $this->normalizeCtaTargetUrl((string) ($postedAd['button_url'] ?? ''));
+            $rawButtonUrl = trim((string) ($postedAd['button_url'] ?? ''));
+            $buttonUrl = CtaTargetUrlNormalizer::normalize($rawButtonUrl);
             $enabled = ! empty($postedAd['enabled']);
             $id = trim((string) ($postedAd['id'] ?? ''));
 
-            if ($name === '' && $badge === '' && $title === '' && $copy === '' && $buttonText === '' && $buttonUrl === '') {
+            if ($name === '' && $badge === '' && $title === '' && $copy === '' && $buttonText === '' && $rawButtonUrl === '') {
                 continue;
             }
 
@@ -927,7 +929,7 @@ class SiteSettingsController extends Controller
 
             $imageUrl = $this->normalizePublicImageUrl((string) ($postedSlide['image_url'] ?? ''));
             $title = trim((string) ($postedSlide['title'] ?? ''));
-            $linkUrl = $this->normalizeCtaTargetUrl((string) ($postedSlide['link_url'] ?? ''));
+            $linkUrl = CtaTargetUrlNormalizer::normalize((string) ($postedSlide['link_url'] ?? ''));
             $enabled = ! empty($postedSlide['enabled']);
 
             if ($imageUrl === '' && $title === '' && $linkUrl === '') {
@@ -972,27 +974,6 @@ class SiteSettingsController extends Controller
         }
 
         return '';
-    }
-
-    /**
-     * 归一化广告按钮链接，兼容相对路径与完整 URL。
-     */
-    private function normalizeCtaTargetUrl(string $url): string
-    {
-        $normalized = trim($url);
-        if ($normalized === '') {
-            return '';
-        }
-
-        if (str_starts_with($normalized, '/')) {
-            return $normalized;
-        }
-
-        if (preg_match('#^https?://#i', $normalized) === 1) {
-            return $normalized;
-        }
-
-        return '/'.ltrim($normalized, '/');
     }
 
     /**

--- a/app/Support/Site/ArticleStickyAdPicker.php
+++ b/app/Support/Site/ArticleStickyAdPicker.php
@@ -25,7 +25,7 @@ final class ArticleStickyAdPicker
 
             $copy = trim((string) ($item['copy'] ?? ''));
             $buttonText = trim((string) ($item['button_text'] ?? ''));
-            $buttonUrl = trim((string) ($item['button_url'] ?? ''));
+            $buttonUrl = CtaTargetUrlNormalizer::normalize((string) ($item['button_url'] ?? ''));
             if ($copy === '' || $buttonText === '' || $buttonUrl === '') {
                 continue;
             }
@@ -36,28 +36,10 @@ final class ArticleStickyAdPicker
                 'title' => trim((string) ($item['title'] ?? '')),
                 'copy' => $copy,
                 'button_text' => $buttonText,
-                'button_url' => self::normalizeCtaTargetUrl($buttonUrl),
+                'button_url' => $buttonUrl,
             ];
         }
 
         return null;
-    }
-
-    private static function normalizeCtaTargetUrl(string $url): string
-    {
-        $normalized = trim($url);
-        if ($normalized === '') {
-            return '';
-        }
-
-        if (str_starts_with($normalized, '/')) {
-            return $normalized;
-        }
-
-        if (preg_match('#^https?://#i', $normalized) === 1) {
-            return $normalized;
-        }
-
-        return '/'.ltrim($normalized, '/');
     }
 }

--- a/app/Support/Site/CtaTargetUrlNormalizer.php
+++ b/app/Support/Site/CtaTargetUrlNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Support\Site;
+
+use Illuminate\Support\Str;
+
+final class CtaTargetUrlNormalizer
+{
+    public static function normalize(string $url): string
+    {
+        if (preg_match('/[\x00-\x1F\x7F]/', $url) === 1) {
+            return '';
+        }
+
+        $normalized = trim($url);
+
+        if ($normalized === '' || str_contains($normalized, '\\')) {
+            return '';
+        }
+
+        if (str_starts_with($normalized, '//')) {
+            return '';
+        }
+
+        if (str_starts_with($normalized, '/')) {
+            return $normalized;
+        }
+
+        if (Str::isUrl($normalized, ['http', 'https'])) {
+            return $normalized;
+        }
+
+        if (preg_match('/^[a-z][a-z0-9+.-]*:/i', $normalized) === 1) {
+            return '';
+        }
+
+        return '/'.ltrim($normalized, '/');
+    }
+}

--- a/tests/Feature/AdminSiteSettingsPageTest.php
+++ b/tests/Feature/AdminSiteSettingsPageTest.php
@@ -561,6 +561,137 @@ class AdminSiteSettingsPageTest extends TestCase
         $this->assertTrue($slides[0]['enabled']);
     }
 
+    public function test_article_detail_ads_reject_protocol_relative_url_without_overwriting_existing_setting(): void
+    {
+        $this->withoutMiddleware(ValidateCsrfToken::class);
+
+        $existingAds = '[{"id":"existing-ad","copy":"Existing copy","button_text":"Existing CTA","button_url":"/existing","enabled":true}]';
+        SiteSetting::query()->create([
+            'setting_key' => 'article_detail_ads',
+            'setting_value' => $existingAds,
+        ]);
+
+        $admin = Admin::query()->create([
+            'username' => 'site_sticky_ads_invalid_admin',
+            'password' => 'secret-123',
+            'email' => 'site-sticky-ads-invalid-admin@example.com',
+            'display_name' => 'Site Sticky Ads Invalid Admin',
+            'role' => 'admin',
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->from(route('admin.site-settings.index'))
+            ->post(route('admin.site-settings.ads'), [
+                'ads' => [[
+                    'name' => 'Unsafe CTA',
+                    'badge' => 'Featured',
+                    'title' => 'Unsafe title',
+                    'copy' => 'Unsafe copy',
+                    'button_text' => 'Open',
+                    'button_url' => '//evil.example/demo',
+                    'enabled' => '1',
+                ]],
+            ])
+            ->assertRedirect(route('admin.site-settings.index'))
+            ->assertSessionHasErrors();
+
+        $this->assertSame(
+            [__('admin.site_settings.ads.validation_required', ['index' => 1])],
+            session('errors')->all()
+        );
+        $this->assertSame(
+            $existingAds,
+            (string) SiteSetting::query()->where('setting_key', 'article_detail_ads')->value('setting_value')
+        );
+    }
+
+    public function test_article_detail_ads_do_not_treat_an_unsafe_url_as_an_empty_row(): void
+    {
+        $this->withoutMiddleware(ValidateCsrfToken::class);
+
+        $existingAds = '[{"id":"existing-ad","copy":"Existing copy","button_text":"Existing CTA","button_url":"/existing","enabled":true}]';
+        SiteSetting::query()->create([
+            'setting_key' => 'article_detail_ads',
+            'setting_value' => $existingAds,
+        ]);
+
+        $admin = Admin::query()->create([
+            'username' => 'site_sticky_ads_unsafe_only_admin',
+            'password' => 'secret-123',
+            'email' => 'site-sticky-ads-unsafe-only-admin@example.com',
+            'display_name' => 'Site Sticky Ads Unsafe Only Admin',
+            'role' => 'admin',
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->from(route('admin.site-settings.index'))
+            ->post(route('admin.site-settings.ads'), [
+                'ads' => [[
+                    'button_url' => '//evil.example/demo',
+                ]],
+            ])
+            ->assertRedirect(route('admin.site-settings.index'))
+            ->assertSessionHasErrors();
+
+        $this->assertSame(
+            $existingAds,
+            (string) SiteSetting::query()->where('setting_key', 'article_detail_ads')->value('setting_value')
+        );
+    }
+
+    public function test_article_detail_ads_save_relative_and_http_urls_in_normalized_form(): void
+    {
+        $this->withoutMiddleware(ValidateCsrfToken::class);
+
+        $admin = Admin::query()->create([
+            'username' => 'site_sticky_ads_admin',
+            'password' => 'secret-123',
+            'email' => 'site-sticky-ads-admin@example.com',
+            'display_name' => 'Site Sticky Ads Admin',
+            'role' => 'admin',
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->post(route('admin.site-settings.ads'), [
+                'ads' => [
+                    [
+                        'id' => 'relative-ad',
+                        'name' => 'Relative CTA',
+                        'badge' => 'Internal',
+                        'title' => 'Internal offer',
+                        'copy' => 'Read the internal offer.',
+                        'button_text' => 'Read',
+                        'button_url' => 'offers/demo',
+                        'enabled' => '1',
+                    ],
+                    [
+                        'id' => 'external-ad',
+                        'name' => 'External CTA',
+                        'badge' => 'Partner',
+                        'title' => 'Partner offer',
+                        'copy' => 'Read the partner offer.',
+                        'button_text' => 'Visit',
+                        'button_url' => 'https://partner.example/demo',
+                        'enabled' => '1',
+                    ],
+                ],
+            ])
+            ->assertRedirect(route('admin.site-settings.index'))
+            ->assertSessionHasNoErrors();
+
+        $savedAds = json_decode(
+            (string) SiteSetting::query()->where('setting_key', 'article_detail_ads')->value('setting_value'),
+            true
+        );
+
+        $this->assertIsArray($savedAds);
+        $this->assertSame('/offers/demo', $savedAds[0]['button_url']);
+        $this->assertSame('https://partner.example/demo', $savedAds[1]['button_url']);
+    }
+
     public function test_article_detail_text_ads_can_be_saved_updated_and_deleted_without_touching_sticky_ads(): void
     {
         $this->withoutMiddleware(ValidateCsrfToken::class);

--- a/tests/Feature/SiteArticleMarkdownRenderTest.php
+++ b/tests/Feature/SiteArticleMarkdownRenderTest.php
@@ -177,6 +177,124 @@ MD);
             ->assertSee('Read more');
     }
 
+    public function test_theme_article_page_skips_unsafe_sticky_ad_and_renders_next_valid_ad(): void
+    {
+        SiteSetting::query()->updateOrCreate(
+            ['setting_key' => 'active_theme'],
+            ['setting_value' => 'tdwh-netease-news-en-20260508']
+        );
+        SiteSetting::query()->updateOrCreate(
+            ['setting_key' => 'article_detail_ads'],
+            ['setting_value' => json_encode([
+                [
+                    'id' => 'unsafe-ad',
+                    'badge' => 'Unsafe',
+                    'title' => 'Unsafe CTA',
+                    'copy' => 'Unsafe sticky ad copy',
+                    'button_text' => 'Unsafe link',
+                    'button_url' => '//evil.example/demo',
+                    'enabled' => true,
+                ],
+                [
+                    'id' => 'safe-ad',
+                    'badge' => 'Safe',
+                    'title' => 'Safe CTA',
+                    'copy' => 'Safe sticky ad copy',
+                    'button_text' => 'Safe link',
+                    'button_url' => '/category/tech',
+                    'enabled' => true,
+                ],
+            ], JSON_UNESCAPED_UNICODE)]
+        );
+        SiteSettingsBag::forget();
+
+        $category = Category::query()->create([
+            'name' => '科技资讯',
+            'slug' => 'tech',
+        ]);
+        $author = Author::query()->create([
+            'name' => 'GEOFlow',
+        ]);
+        $article = Article::query()->create([
+            'title' => 'Sticky Ad 安全回退测试',
+            'slug' => 'sticky-ad-safe-fallback-test',
+            'excerpt' => '',
+            'content' => '## 正文',
+            'category_id' => $category->id,
+            'author_id' => $author->id,
+            'status' => 'published',
+            'review_status' => 'approved',
+            'is_ai_generated' => 1,
+            'published_at' => now(),
+        ]);
+
+        $this->get(route('site.article', $article->slug))
+            ->assertOk()
+            ->assertSee('Safe CTA')
+            ->assertSee('Safe sticky ad copy')
+            ->assertSee('href="/category/tech"', false)
+            ->assertDontSee('Unsafe CTA')
+            ->assertDontSee('evil.example');
+    }
+
+    public function test_theme_article_page_omits_sticky_ad_when_all_enabled_ads_are_unsafe(): void
+    {
+        SiteSetting::query()->updateOrCreate(
+            ['setting_key' => 'active_theme'],
+            ['setting_value' => 'tdwh-netease-news-en-20260508']
+        );
+        SiteSetting::query()->updateOrCreate(
+            ['setting_key' => 'article_detail_ads'],
+            ['setting_value' => json_encode([
+                [
+                    'id' => 'protocol-relative-ad',
+                    'badge' => 'Unsafe',
+                    'title' => 'Protocol-relative CTA',
+                    'copy' => 'Protocol-relative sticky ad copy',
+                    'button_text' => 'Unsafe link',
+                    'button_url' => '//evil.example/demo',
+                    'enabled' => true,
+                ],
+                [
+                    'id' => 'script-ad',
+                    'badge' => 'Unsafe',
+                    'title' => 'Script CTA',
+                    'copy' => 'Script sticky ad copy',
+                    'button_text' => 'Unsafe script',
+                    'button_url' => 'javascript:alert(1)',
+                    'enabled' => true,
+                ],
+            ], JSON_UNESCAPED_UNICODE)]
+        );
+        SiteSettingsBag::forget();
+
+        $category = Category::query()->create([
+            'name' => '科技资讯',
+            'slug' => 'tech',
+        ]);
+        $author = Author::query()->create([
+            'name' => 'GEOFlow',
+        ]);
+        $article = Article::query()->create([
+            'title' => 'Sticky Ad 全量拦截测试',
+            'slug' => 'sticky-ad-all-unsafe-test',
+            'excerpt' => '',
+            'content' => '## 正文',
+            'category_id' => $category->id,
+            'author_id' => $author->id,
+            'status' => 'published',
+            'review_status' => 'approved',
+            'is_ai_generated' => 1,
+            'published_at' => now(),
+        ]);
+
+        $this->get(route('site.article', $article->slug))
+            ->assertOk()
+            ->assertDontSee('class="ne-ad-slot"', false)
+            ->assertDontSee('evil.example')
+            ->assertDontSee('javascript:alert(1)');
+    }
+
     public function test_article_page_renders_content_text_ads_around_article_body(): void
     {
         SiteSetting::query()->updateOrCreate(

--- a/tests/Unit/CtaTargetUrlNormalizerTest.php
+++ b/tests/Unit/CtaTargetUrlNormalizerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Site\CtaTargetUrlNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class CtaTargetUrlNormalizerTest extends TestCase
+{
+    #[DataProvider('safeUrls')]
+    public function test_safe_cta_urls_are_normalized(string $input, string $expected): void
+    {
+        $this->assertSame($expected, CtaTargetUrlNormalizer::normalize($input));
+    }
+
+    #[DataProvider('unsafeUrls')]
+    public function test_unsafe_cta_urls_are_rejected(string $input): void
+    {
+        $this->assertSame('', CtaTargetUrlNormalizer::normalize($input));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function safeUrls(): array
+    {
+        return [
+            'root-relative path' => ['/offers/demo', '/offers/demo'],
+            'trimmed root-relative path' => ['  /offers/demo  ', '/offers/demo'],
+            'plain relative path' => ['offers/demo', '/offers/demo'],
+            'relative path with query and fragment' => ['offers/demo?utm_source=cta#pricing', '/offers/demo?utm_source=cta#pricing'],
+            'https URL' => ['https://partner.example/demo?utm_source=cta#pricing', 'https://partner.example/demo?utm_source=cta#pricing'],
+            'http URL' => ['http://partner.example/demo', 'http://partner.example/demo'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function unsafeUrls(): array
+    {
+        return [
+            'empty string' => [''],
+            'blank string' => ['   '],
+            'protocol-relative URL' => ['//evil.example/demo'],
+            'multiple leading slashes' => ['///evil.example/demo'],
+            'authority with backslashes' => ['\\\\evil.example/demo'],
+            'root path with backslashes' => ['/\\\\evil.example/demo'],
+            'relative path with a backslash' => ['offers\\demo'],
+            'malformed https URL' => ['https:///evil.example/demo'],
+            'malformed http URL' => ['http:/evil.example/demo'],
+            'javascript scheme' => ['javascript:alert(1)'],
+            'data scheme' => ['data:text/html,unsafe'],
+            'mailto scheme' => ['mailto:security@example.com'],
+            'embedded control character' => ["https://safe.example/\nunsafe"],
+        ];
+    }
+}


### PR DESCRIPTION
## 变更说明 / Summary

- Centralize CTA target URL normalization for sticky ads and homepage carousel links.
- Reject protocol-relative URLs, backslashes, control characters, malformed HTTP(S) URLs, and unsupported schemes before persistence.
- Revalidate historical sticky-ad settings during rendering, skip unsafe entries, and continue to the next valid enabled ad.
- Add unit and feature regression coverage for accepted URLs, rejected edge cases, admin validation, persistence integrity, safe fallback, and all-invalid rendering.

Fixes #130

## 验证 / Verification

- `composer validate --strict` — passed.
- `vendor/bin/pint --test --format agent` — passed.
- `npm run build` — passed.
- `php artisan test --compact tests/Unit/CtaTargetUrlNormalizerTest.php tests/Feature/AdminSiteSettingsPageTest.php tests/Feature/SiteArticleMarkdownRenderTest.php` — 19 passed, 45 project warnings, 528 assertions.
- `composer test` — 357 passed, 13 skipped, 3,120 project warnings, 34,946 assertions.
- `npm run test:analytics` — 191 passed.
- `composer audit --locked --no-interaction` — no security advisories found.
- `npm audit --audit-level=high --registry=https://registry.npmjs.org` — 0 vulnerabilities.

## CLA 声明 / CLA declaration

可构成版权作品的贡献必须接受 [GEOFlow Contributor License Agreement v1.0](https://github.com/yaojingang/GEOFlow/blob/main/CLA.md)。
Copyrightable contributions require acceptance of the [GEOFlow Contributor License Agreement v1.0](https://github.com/yaojingang/GEOFlow/blob/main/CLA.md).

以下内容会公开显示。如需私下签署，请将姓名字段填写为 `Private CLA requested`，并在合并前与维护者完成单独签署。
The following information is public. To sign privately, enter `Private CLA requested` in the name field and complete a separate signature with the maintainer before merge.

- 贡献者类型 / Contributor type: `个人 Individual` / `企业 Entity`
- 法定姓名或企业法定名称 / Legal name or entity name:
- 企业授权代表姓名及职务（如适用）/ Authorized representative and title (if applicable):
- GitHub 用户名 / GitHub username:
- 接受日期 / Date accepted (`YYYY-MM-DD`):
- [ ] 我已阅读并接受 GEOFlow CLA v1.0，并确认有权授予其中约定的权利。I have read and accept the GEOFlow CLA v1.0 and confirm that I have authority to grant the rights described in it.

## 检查清单 / Checklist

- [x] 我已说明第三方材料的来源、许可证和修改情况，或本次提交不包含第三方材料。
      I have identified the source, license, and modifications of third-party materials, or this contribution contains none.
- [x] 我没有提交凭据、客户数据或其他敏感信息。
      I have not submitted credentials, customer data, or other sensitive information.
- [x] 我已为行为变化补充测试或说明无需新增测试的原因。
      I have added tests for behavior changes or explained why no new test is needed.
