### PR TITLE
fix: keep distribution-only articles private

### DIFF
--- a/app/Console/Commands/ReconcileDistributionOnlyArticlesCommand.php
+++ b/app/Console/Commands/ReconcileDistributionOnlyArticlesCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+class ReconcileDistributionOnlyArticlesCommand extends Command
+{
+    protected $signature = 'geoflow:reconcile-distribution-only-articles
+        {--apply : Persist the repair; the default is a dry run}';
+
+    protected $description = 'Keep articles from distribution-only tasks private on the primary site';
+
+    public function handle(): int
+    {
+        $apply = (bool) $this->option('apply');
+        $matched = 0;
+        $reconciled = 0;
+
+        $this->invalidArticlesQuery()
+            ->select(['articles.id'])
+            ->chunkById(200, function (Collection $articles) use ($apply, &$matched, &$reconciled): void {
+                $matched += $articles->count();
+                if (! $apply) {
+                    return;
+                }
+
+                $reconciled += $this->invalidArticlesQuery()
+                    ->whereKey($articles->modelKeys())
+                    ->update([
+                        'status' => 'private',
+                        'published_at' => null,
+                        'updated_at' => now(),
+                    ]);
+            }, column: 'articles.id', alias: 'id');
+
+        if ($apply) {
+            $this->info("Reconciled distribution-only published articles: {$reconciled}");
+        } else {
+            $this->info("Matched distribution-only published articles: {$matched} (dry run)");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /** @return Builder<Article> */
+    private function invalidArticlesQuery(): Builder
+    {
+        return Article::query()
+            ->where('articles.status', 'published')
+            ->whereHas('task', static fn (Builder $task): Builder => $task
+                ->where('publish_scope', 'distribution_only'));
+    }
+}

--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -537,7 +537,7 @@ class ArticleController extends Controller
             if ($gateRejection instanceof ArticleRiskGateException || $gateRejection instanceof ArticleAiQualityGateException) {
                 throw $gateRejection;
             }
-            if ($article->status === 'published') {
+            if ($workflowState['status'] === 'published') {
                 $this->distributionOrchestrator->enqueueForArticle($article);
             }
         } catch (ArticleRiskGateException|ArticleAiQualityGateException $e) {
@@ -960,7 +960,7 @@ class ArticleController extends Controller
                     ->route('admin.articles.edit', ['articleId' => $articleId])
                     ->with('message', __('admin.articles.ai_quality.recheck_queued'));
             }
-            if ($article->status === 'published') {
+            if ($workflowState['status'] === 'published') {
                 $this->distributionOrchestrator->enqueueForArticle($article);
             }
         } catch (ArticleRiskGateException|ArticleAiQualityGateException $e) {

--- a/app/Http/Controllers/Site/ArchiveController.php
+++ b/app/Http/Controllers/Site/ArchiveController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Site;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Services\Site\SiteScopedArticleQuery;
 use App\Support\Site\ArticleHtmlPresenter;
 use App\Support\Site\SiteSettingsBag;
 use App\Support\Site\SiteThemeViewResolver;
@@ -17,6 +18,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ArchiveController extends Controller
 {
+    public function __construct(private readonly SiteScopedArticleQuery $siteArticles) {}
+
     public function index(): View
     {
         $map = SiteSettingsBag::all();
@@ -43,8 +46,7 @@ class ArchiveController extends Controller
             ],
         };
 
-        $archives = Article::query()
-            ->published()
+        $archives = $this->siteArticles->query()
             ->selectRaw("{$yearExpression} AS archive_year")
             ->selectRaw("{$monthExpression} AS archive_month")
             ->selectRaw('COUNT(*) AS archive_count')
@@ -95,9 +97,8 @@ class ArchiveController extends Controller
         $siteDescription = (string) ($map['site_description'] ?? config('geoflow.site_description', ''));
         $siteKeywords = (string) ($map['site_keywords'] ?? config('geoflow.site_keywords', ''));
 
-        $articles = Article::query()
+        $articles = $this->siteArticles->query()
             ->with(['category', 'author'])
-            ->published()
             ->where(function ($query) use ($start, $end): void {
                 $query->whereBetween('published_at', [$start, $end])
                     ->orWhere(function ($fallback) use ($start, $end): void {

--- a/app/Services/GeoFlow/ArticleAiQualityInspectionService.php
+++ b/app/Services/GeoFlow/ArticleAiQualityInspectionService.php
@@ -27,6 +27,7 @@ use App\Services\GeoFlow\KnowledgeFacts\ArticleAtomicFactInspector;
 use App\Support\GeoFlow\AiModelFailoverDecider;
 use App\Support\GeoFlow\AiQualityRetrievalBasis;
 use App\Support\GeoFlow\AiQualityRetrievalMode;
+use App\Support\GeoFlow\ArticleWorkflow;
 use Carbon\CarbonInterface;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Date;
@@ -3018,29 +3019,21 @@ class ArticleAiQualityInspectionService
                 return;
             }
 
-            $requestedWorkflowState = is_array($check->execution_meta['requested_workflow_state'] ?? null)
-                ? $check->execution_meta['requested_workflow_state']
-                : null;
-            $targetState = $requestedWorkflowState !== null
-                && in_array((string) ($requestedWorkflowState['status'] ?? ''), ['published', 'private'], true)
-                ? $requestedWorkflowState
-                : ['status' => 'draft', 'review_status' => 'approved', 'published_at' => null];
-            $this->applyPassedWorkflowUnderRolloutFence($checkId, $targetState);
+            $this->applyPassedWorkflowUnderRolloutFence($checkId);
         } catch (Throwable $exception) {
             $this->failWorkflowApplyAttempt($checkId);
             report($exception);
         }
     }
 
-    /** @param array{status:string,review_status:string,published_at:mixed} $targetState */
-    private function applyPassedWorkflowUnderRolloutFence(int $checkId, array $targetState): bool
+    private function applyPassedWorkflowUnderRolloutFence(int $checkId): bool
     {
         $checkInfo = ArticleAiQualityCheck::query()->whereKey($checkId)->first(['article_id', 'task_id']);
         if (! $checkInfo) {
             return false;
         }
 
-        return DB::transaction(function () use ($checkId, $checkInfo, $targetState): bool {
+        return DB::transaction(function () use ($checkId, $checkInfo): bool {
             $rollout = ArticleAiQualityRollout::query()->whereKey(1)->lockForUpdate()->first();
             $committedEpoch = max(1, (int) ($rollout?->epoch ?? 1));
             $article = Article::query()->whereKey((int) $checkInfo->article_id)->lockForUpdate()->first();
@@ -3064,6 +3057,19 @@ class ArticleAiQualityInspectionService
             if ($task instanceof Task && ! $task->trashed()) {
                 $check->setRelation('task', $task);
             }
+
+            $requestedWorkflowState = is_array($check->execution_meta['requested_workflow_state'] ?? null)
+                ? $check->execution_meta['requested_workflow_state']
+                : null;
+            $targetState = $requestedWorkflowState !== null
+                && in_array((string) ($requestedWorkflowState['status'] ?? ''), ['published', 'private'], true)
+                ? $requestedWorkflowState
+                : ['status' => 'draft', 'review_status' => 'approved', 'published_at' => null];
+            $distributionRequested = (string) $targetState['status'] === 'published';
+            $targetState = ArticleWorkflow::normalizeForPublishScope(
+                $targetState,
+                $task?->publish_scope,
+            );
 
             $this->rolloutPolicy->forget();
             $manualReviewRequired = (bool) data_get(
@@ -3143,7 +3149,7 @@ class ArticleAiQualityInspectionService
                     false,
                 );
             }
-            if ((string) $article->status === 'published') {
+            if ($distributionRequested) {
                 app(DistributionOrchestrator::class)->enqueueForArticle($article, throwOnFailure: true);
             }
             $this->setWorkflowApplyStatus($check, 'succeeded');

--- a/app/Services/GeoFlow/ArticleAiQualityInvalidationService.php
+++ b/app/Services/GeoFlow/ArticleAiQualityInvalidationService.php
@@ -41,13 +41,18 @@ class ArticleAiQualityInvalidationService
         return $updated;
     }
 
-    public function invalidateArticle(Article|int $article, string $reason, bool $reconcile = true): int
-    {
+    public function invalidateArticle(
+        Article|int $article,
+        string $reason,
+        bool $reconcile = true,
+        bool $preserveWorkflow = false,
+    ): int {
         $articleId = $article instanceof Article ? (int) $article->id : $article;
         [$updated] = $this->invalidateChecks(
             ArticleAiQualityCheck::query()->where('article_id', $articleId),
             'input_changed',
             $reason,
+            $preserveWorkflow ? [$articleId] : [],
         );
         $this->invalidateOptimizationArticles([$articleId], $reason);
 
@@ -116,8 +121,12 @@ class ArticleAiQualityInvalidationService
         return $updated + $optimizationUpdated;
     }
 
-    public function invalidateTask(int $taskId, string $reason): int
-    {
+    /** @param iterable<int> $preserveWorkflowArticleIds */
+    public function invalidateTask(
+        int $taskId,
+        string $reason,
+        iterable $preserveWorkflowArticleIds = [],
+    ): int {
         $articles = Article::withTrashed()->where('task_id', $taskId);
         [$updated, $affectedArticleIds] = $this->invalidateChecks(
             ArticleAiQualityCheck::query()->where(function (Builder $query) use ($taskId, $articles): void {
@@ -126,6 +135,7 @@ class ArticleAiQualityInvalidationService
             }),
             'policy_changed',
             $reason,
+            $preserveWorkflowArticleIds,
         );
         $this->dispatchReconcile($this->articleIds($articles)->merge($affectedArticleIds));
         $this->invalidateTaskOptimization($taskId, $reason);
@@ -388,17 +398,30 @@ class ArticleAiQualityInvalidationService
         return $updated;
     }
 
-    /** @return array{int, Collection<int, int>} */
-    private function invalidateChecks(Builder $query, string $errorCode, string $reason): array
-    {
+    /**
+     * @param  iterable<int>  $preserveWorkflowArticleIds
+     * @return array{int, Collection<int, int>}
+     */
+    private function invalidateChecks(
+        Builder $query,
+        string $errorCode,
+        string $reason,
+        iterable $preserveWorkflowArticleIds = [],
+    ): array {
         $updated = 0;
         $affectedArticleIds = [];
+        $preservedArticleIds = collect($preserveWorkflowArticleIds)
+            ->map(static fn (mixed $articleId): int => (int) $articleId)
+            ->filter(static fn (int $articleId): bool => $articleId > 0)
+            ->unique()
+            ->values();
         (clone $query)
             ->whereIn('status', ['queued', 'running', 'completed', 'failed'])
             ->select(['id', 'article_id'])
             ->chunkById(500, function (Collection $checks) use (
                 $errorCode,
                 $reason,
+                $preservedArticleIds,
                 &$updated,
                 &$affectedArticleIds,
             ): void {
@@ -431,8 +454,9 @@ class ArticleAiQualityInvalidationService
                         'updated_at' => $timestamp,
                     ]);
                 if ($articleIds->isNotEmpty()) {
+                    $workflowArticleIds = $articleIds->diff($preservedArticleIds)->values();
                     Article::query()
-                        ->whereIn('id', $articleIds->all())
+                        ->whereIn('id', $workflowArticleIds->all())
                         ->where('status', '!=', 'published')
                         ->where('review_status', '!=', 'rejected')
                         ->update([

--- a/app/Services/GeoFlow/ArticleGeoFlowService.php
+++ b/app/Services/GeoFlow/ArticleGeoFlowService.php
@@ -35,6 +35,7 @@ class ArticleGeoFlowService
         private readonly ArticleAiOptimizationCoordinator $articleAiOptimizationCoordinator,
         private readonly ArticleAiQualityConfigurationService $articleAiQualityConfigurationService,
         private readonly AiQualityAuditService $aiQualityAuditService,
+        private readonly DistributionOrchestrator $distributionOrchestrator,
     ) {}
 
     public function listArticles(int $page = 1, int $perPage = 20, array $filters = []): array
@@ -168,6 +169,9 @@ class ArticleGeoFlowService
         }
         if ($article->ai_quality_required_at_creation) {
             $this->articleAiQualityInspectionService->createOrReuse($article, trigger: 'api_create');
+        }
+        if ($workflowState['status'] === 'published') {
+            $this->distributionOrchestrator->enqueueForArticle($article);
         }
 
         return $this->getArticle((int) $article->id);
@@ -467,8 +471,9 @@ class ArticleGeoFlowService
         }
 
         $normalized['updated_at'] = now();
+        $preserveWorkflowDuringQualityInvalidation = false;
 
-        DB::transaction(function () use ($articleId, $normalized, $auditAdminId, $hasRiskRelevantChanges, $hasQualityRelevantChanges): void {
+        DB::transaction(function () use ($articleId, $normalized, $auditAdminId, $hasRiskRelevantChanges, $hasQualityRelevantChanges, &$preserveWorkflowDuringQualityInvalidation): void {
             $lockedArticle = Article::query()
                 ->whereKey($articleId)
                 ->lockForUpdate()
@@ -479,11 +484,14 @@ class ArticleGeoFlowService
                 $normalized['ai_quality_policy_version'] = $nextPolicyVersion;
             }
             if (array_key_exists('task_id', $normalized)) {
-                $this->rebindArticleTask(
+                $preserveWorkflowDuringQualityInvalidation = $this->rebindArticleTask(
                     $lockedArticle,
                     $normalized['task_id'],
                     $nextPolicyVersion,
                 );
+                if ($hasRiskRelevantChanges) {
+                    $preserveWorkflowDuringQualityInvalidation = false;
+                }
                 unset($normalized['task_id'], $normalized['ai_quality_policy_version']);
             }
             if ($normalized !== []) {
@@ -496,17 +504,21 @@ class ArticleGeoFlowService
         });
 
         if ($hasQualityRelevantChanges) {
-            $this->articleAiQualityInvalidationService->invalidateArticle($articleId, '文章内容或任务关联已更新');
+            $this->articleAiQualityInvalidationService->invalidateArticle(
+                $articleId,
+                '文章内容或任务关联已更新',
+                preserveWorkflow: $preserveWorkflowDuringQualityInvalidation,
+            );
         }
 
         return $this->getArticle($articleId);
     }
 
-    private function rebindArticleTask(Article $article, ?int $targetTaskId, int $nextPolicyVersion): void
+    private function rebindArticleTask(Article $article, ?int $targetTaskId, int $nextPolicyVersion): bool
     {
         $currentTaskId = $article->task_id ? (int) $article->task_id : null;
         if ($currentTaskId === $targetTaskId) {
-            return;
+            return false;
         }
 
         $currentTask = $currentTaskId === null
@@ -539,7 +551,7 @@ class ArticleGeoFlowService
                 'ai_quality_policy_snapshot' => $this->articleAiQualityPolicyResolver->snapshot($policy),
             ])->save();
 
-            return;
+            return false;
         }
 
         $targetTask = Task::query()
@@ -569,10 +581,22 @@ class ArticleGeoFlowService
                 'reason_code' => $exception->getMessage(),
             ]);
         }
+        $currentWorkflowState = [
+            'status' => (string) $article->status,
+            'review_status' => (string) $article->review_status,
+            'published_at' => $article->published_at,
+        ];
+        $publishScopeWorkflowState = ArticleWorkflow::normalizeForPublishScope(
+            $currentWorkflowState,
+            $targetTask->publish_scope,
+        );
         $article->forceFill([
             'ai_quality_required_at_creation' => (bool) ($policy['required'] ?? false),
             'ai_quality_policy_snapshot' => $this->articleAiQualityPolicyResolver->snapshot($policy),
+            ...$publishScopeWorkflowState,
         ])->save();
+
+        return $publishScopeWorkflowState !== $currentWorkflowState;
     }
 
     /**
@@ -730,6 +754,7 @@ class ArticleGeoFlowService
         }
 
         $desiredStatus = $article['status'] ?? 'draft';
+        $distributionArticle = null;
         if (in_array($reviewStatus, ['approved', 'auto_approved'], true)) {
             $taskNeedReview = 1;
             if (! empty($article['task_id'])) {
@@ -758,9 +783,10 @@ class ArticleGeoFlowService
                 $riskOverrideReason,
                 $fallbackWorkflowState,
                 $reviewStatus,
+                &$distributionArticle,
             ): ArticleRiskGateException|ArticleAiQualityGateException|null {
                 try {
-                    $this->articleWorkflowTransitionService->transition(
+                    $distributionArticle = $this->articleWorkflowTransitionService->transition(
                         Article::query()->findOrFail($articleId),
                         $workflowState,
                         'api_review',
@@ -807,6 +833,10 @@ class ArticleGeoFlowService
             });
         }
 
+        if ($workflowState['status'] === 'published') {
+            $this->distributionOrchestrator->enqueueForArticle($distributionArticle);
+        }
+
         return $this->getArticle($articleId);
     }
 
@@ -823,7 +853,7 @@ class ArticleGeoFlowService
         }
 
         try {
-            $this->articleWorkflowTransitionService->transition(
+            $article = $this->articleWorkflowTransitionService->transition(
                 $article,
                 ArticleWorkflow::normalizeState('published', $reviewStatus, $article->published_at),
                 'api_publish',
@@ -842,6 +872,8 @@ class ArticleGeoFlowService
         } catch (ArticleAiQualityGateException $exception) {
             throw $this->qualityBlockedException(Article::query()->findOrFail($articleId), $exception);
         }
+
+        $this->distributionOrchestrator->enqueueForArticle($article);
 
         return $this->getArticle($articleId);
     }

--- a/app/Services/GeoFlow/ArticleWorkflowTransitionService.php
+++ b/app/Services/GeoFlow/ArticleWorkflowTransitionService.php
@@ -5,7 +5,9 @@ namespace App\Services\GeoFlow;
 use App\Exceptions\ArticleAiQualityGateException;
 use App\Exceptions\ArticleRiskGateException;
 use App\Models\Article;
+use App\Models\ArticleAiQualityCheck;
 use App\Models\Task;
+use App\Support\GeoFlow\ArticleWorkflow;
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
@@ -38,6 +40,7 @@ class ArticleWorkflowTransitionService
             $rejectedWorkflowState,
             $lockedGuard,
         ): Article|ArticleRiskGateException|ArticleAiQualityGateException {
+            $distributionRequested = (string) $workflowState['status'] === 'published';
             $taskId = (int) (Article::query()
                 ->whereKey($article->getKey())
                 ->value('task_id') ?? 0);
@@ -47,6 +50,21 @@ class ArticleWorkflowTransitionService
             if ($lockedTask instanceof Task) {
                 $lockedTask->load(['qualityPrompt', 'qualityModel', 'aiModel', 'knowledgeBases']);
                 $lockedArticle->setRelation('task', $lockedTask);
+            }
+
+            if (! $distributionRequested) {
+                $this->cancelPendingDistributionIntent($lockedArticle);
+            }
+
+            $workflowState = ArticleWorkflow::normalizeForPublishScope(
+                $workflowState,
+                $lockedTask?->publish_scope,
+            );
+            if ($rejectedWorkflowState !== null) {
+                $rejectedWorkflowState = ArticleWorkflow::normalizeForPublishScope(
+                    $rejectedWorkflowState,
+                    $lockedTask?->publish_scope,
+                );
             }
 
             if ($lockedGuard !== null) {
@@ -64,7 +82,12 @@ class ArticleWorkflowTransitionService
             } catch (ArticleRiskGateException|ArticleAiQualityGateException $exception) {
                 $preservePublishedArticle = $exception instanceof ArticleAiQualityGateException
                     && (string) $lockedArticle->status === 'published';
-                if ($rejectedWorkflowState !== null && ! $preservePublishedArticle) {
+                if ($preservePublishedArticle && $this->isDistributionOnly($lockedTask)) {
+                    $lockedArticle->update([
+                        'status' => 'private',
+                        'published_at' => null,
+                    ]);
+                } elseif ($rejectedWorkflowState !== null && ! $preservePublishedArticle) {
                     $lockedArticle->update([
                         'status' => $rejectedWorkflowState['status'],
                         'review_status' => $rejectedWorkflowState['review_status'],
@@ -91,6 +114,47 @@ class ArticleWorkflowTransitionService
         return $result;
     }
 
+    /**
+     * Replace any still-applicable publish request with the caller's newer private intent.
+     * The caller must hold the article row lock before invoking this method.
+     */
+    public function cancelPendingDistributionIntent(Article $article): int
+    {
+        $updated = 0;
+        $checks = ArticleAiQualityCheck::query()
+            ->where('article_id', (int) $article->id)
+            ->where('gate_applied', true)
+            ->where('evaluation_mode', '!=', 'optimization_candidate')
+            ->whereIn('status', ['queued', 'running', 'completed'])
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->get();
+
+        foreach ($checks as $check) {
+            $executionMeta = is_array($check->execution_meta) ? $check->execution_meta : [];
+            $requestedWorkflowState = is_array($executionMeta['requested_workflow_state'] ?? null)
+                ? $executionMeta['requested_workflow_state']
+                : null;
+            if ((string) ($requestedWorkflowState['status'] ?? '') !== 'published') {
+                continue;
+            }
+            if ((string) data_get($executionMeta, 'workflow_apply.status') === 'succeeded') {
+                continue;
+            }
+
+            $executionMeta['requested_workflow_state'] = [
+                'status' => 'private',
+                'review_status' => (string) ($requestedWorkflowState['review_status'] ?? 'approved'),
+                'published_at' => null,
+            ];
+            $executionMeta['distribution_intent_cancelled_at'] = now()->toIso8601String();
+            $check->forceFill(['execution_meta' => $executionMeta])->save();
+            $updated++;
+        }
+
+        return $updated;
+    }
+
     private function lockTaskBeforeArticle(int $taskId): ?Task
     {
         if ($taskId <= 0) {
@@ -114,5 +178,10 @@ class ArticleWorkflowTransitionService
         }
 
         return $article;
+    }
+
+    private function isDistributionOnly(?Task $task): bool
+    {
+        return $task instanceof Task && (string) $task->publish_scope === 'distribution_only';
     }
 }

--- a/app/Services/GeoFlow/TaskLifecycleService.php
+++ b/app/Services/GeoFlow/TaskLifecycleService.php
@@ -455,8 +455,9 @@ class TaskLifecycleService
         $knowledgeBaseIds = $knowledgeBaseIdsProvided ? $normalized['knowledge_base_ids'] : [];
         unset($normalized['knowledge_base_ids']);
         $samplingWasDisabled = false;
+        $preserveWorkflowArticleIds = [];
 
-        DB::transaction(function () use (&$qualityConfigurationChanged, &$qualityControlConfigurationChanged, &$optimizationLevelChanged, &$optimizationWasDisabled, &$samplingWasDisabled, $normalized, $knowledgeBaseIdsProvided, $knowledgeBaseIds, $status, $taskId, $canManageHostedTask, $auditAdminId, $apiTokenId, $qualityConfigurationRequested, $expectedQualityVersion, $accessAdmin): void {
+        DB::transaction(function () use (&$qualityConfigurationChanged, &$qualityControlConfigurationChanged, &$optimizationLevelChanged, &$optimizationWasDisabled, &$samplingWasDisabled, &$preserveWorkflowArticleIds, $normalized, $knowledgeBaseIdsProvided, $knowledgeBaseIds, $status, $taskId, $canManageHostedTask, $auditAdminId, $apiTokenId, $qualityConfigurationRequested, $expectedQualityVersion, $accessAdmin): void {
             Article::withTrashed()
                 ->where('task_id', $taskId)
                 ->orderBy('id')
@@ -645,6 +646,26 @@ class TaskLifecycleService
                 Task::query()->whereKey($taskId)->update($normalized);
             }
 
+            $publishScopeNarrowed = array_key_exists('publish_scope', $normalized)
+                && (string) $normalized['publish_scope'] === 'distribution_only'
+                && (string) $current->publish_scope !== 'distribution_only';
+            if ($publishScopeNarrowed) {
+                $publishedArticles = Article::withTrashed()
+                    ->where('task_id', $taskId)
+                    ->where('status', 'published');
+                $preserveWorkflowArticleIds = (clone $publishedArticles)
+                    ->pluck('articles.id')
+                    ->map('intval')
+                    ->all();
+                if ($preserveWorkflowArticleIds !== []) {
+                    $publishedArticles->update([
+                        'status' => 'private',
+                        'published_at' => null,
+                        'updated_at' => now(),
+                    ]);
+                }
+            }
+
             if ($knowledgeBaseIdsProvided) {
                 $this->syncTaskKnowledgeBases($taskId, is_array($knowledgeBaseIds) ? $knowledgeBaseIds : []);
             }
@@ -703,7 +724,11 @@ class TaskLifecycleService
         });
 
         if ($qualityConfigurationChanged) {
-            $this->articleAiQualityInvalidationService->invalidateTask($taskId, '任务质检配置或知识依据已更新');
+            $this->articleAiQualityInvalidationService->invalidateTask(
+                $taskId,
+                '任务质检配置或知识依据已更新',
+                preserveWorkflowArticleIds: $preserveWorkflowArticleIds,
+            );
         }
 
         $task = $this->getTask($taskId, $responseViewer);

--- a/app/Services/Site/SiteScopedArticleQuery.php
+++ b/app/Services/Site/SiteScopedArticleQuery.php
@@ -22,7 +22,14 @@ final class SiteScopedArticleQuery
     public function apply(Builder $query): Builder
     {
         if (! $this->currentSite->isHosted()) {
-            return $query->published();
+            return $query
+                ->published()
+                ->where(function (Builder $articles): void {
+                    $articles
+                        ->whereNull('articles.task_id')
+                        ->orWhereHas('task', fn (Builder $task): Builder => $task
+                            ->where('publish_scope', '!=', 'distribution_only'));
+                });
         }
 
         $profileId = (int) $this->currentSite->profileId();

--- a/app/Support/GeoFlow/ArticleWorkflow.php
+++ b/app/Support/GeoFlow/ArticleWorkflow.php
@@ -55,6 +55,22 @@ final class ArticleWorkflow
         ];
     }
 
+    /**
+     * @param  array{status: string, review_status: string, published_at: mixed}  $workflowState
+     * @return array{status: string, review_status: string, published_at: mixed}
+     */
+    public static function normalizeForPublishScope(array $workflowState, ?string $publishScope): array
+    {
+        if ((string) $publishScope !== 'distribution_only' || $workflowState['status'] !== 'published') {
+            return $workflowState;
+        }
+
+        $workflowState['status'] = 'private';
+        $workflowState['published_at'] = null;
+
+        return $workflowState;
+    }
+
     public static function generateUniqueSlug(string $title, ?int $excludeArticleId = null): string
     {
         $slug = self::randomSlug(8);

--- a/tests/Feature/AdminArticleAiQualityTest.php
+++ b/tests/Feature/AdminArticleAiQualityTest.php
@@ -14,6 +14,7 @@ use App\Models\Prompt;
 use App\Models\Task;
 use App\Services\GeoFlow\ArticleAiQualityInspectionService;
 use App\Services\GeoFlow\ArticleGeoFlowService;
+use App\Services\GeoFlow\TaskLifecycleService;
 use App\Support\GeoFlow\AiQualityRetrievalMode;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
@@ -1385,6 +1386,109 @@ class AdminArticleAiQualityTest extends TestCase
         $this->assertTrue($article->ai_quality_required_at_creation);
         $this->assertTrue((bool) data_get($article->ai_quality_policy_snapshot, 'required'));
         $this->assertSame($taskId, $article->task_id);
+    }
+
+    public function test_api_task_rebinding_keeps_a_published_article_private_for_distribution_only_scope(): void
+    {
+        Queue::fake();
+        [$admin, $article] = $this->qualityArticle();
+        $task = $article->task()->firstOrFail();
+        $task->forceFill(['publish_scope' => 'distribution_only'])->save();
+        $check = app(ArticleAiQualityInspectionService::class)->createOrReuse($article, dispatch: false);
+        $check->forceFill([
+            'status' => 'completed',
+            'decision' => 'passed',
+            'score' => 96,
+            'active_dedupe_key' => null,
+            'finished_at' => now(),
+        ])->save();
+        $article->forceFill([
+            'task_id' => null,
+            'status' => 'published',
+            'review_status' => 'approved',
+            'published_at' => now(),
+            'ai_quality_required_at_creation' => false,
+            'ai_quality_policy_snapshot' => null,
+        ])->save();
+
+        app(ArticleGeoFlowService::class)->updateArticle($article->id, [
+            'task_id' => $task->id,
+        ], $admin->id);
+
+        $article->refresh();
+        $this->assertSame($task->id, $article->task_id);
+        $this->assertSame('private', $article->status);
+        $this->assertSame('approved', $article->review_status);
+        $this->assertNull($article->published_at);
+        $this->assertSame('stale', $check->fresh()->status);
+    }
+
+    public function test_task_scope_narrowing_preserves_approved_private_workflow_when_staling_quality_checks(): void
+    {
+        Queue::fake();
+        [$admin, $article] = $this->qualityArticle();
+        $article->task()->update(['status' => 'paused']);
+        $check = app(ArticleAiQualityInspectionService::class)->createOrReuse($article, dispatch: false);
+        $check->forceFill([
+            'status' => 'completed',
+            'decision' => 'passed',
+            'score' => 96,
+            'active_dedupe_key' => null,
+            'finished_at' => now(),
+        ])->save();
+        $article->forceFill([
+            'status' => 'published',
+            'review_status' => 'approved',
+            'published_at' => now(),
+        ])->save();
+
+        app(TaskLifecycleService::class)->updateTask(
+            (int) $article->task_id,
+            ['publish_scope' => 'distribution_only'],
+            auditAdminId: $admin->id,
+        );
+
+        $article->refresh();
+        $this->assertSame('private', $article->status);
+        $this->assertSame('approved', $article->review_status);
+        $this->assertNull($article->published_at);
+        $this->assertSame('stale', $check->fresh()->status);
+    }
+
+    public function test_api_task_rebinding_with_content_changes_still_requires_a_fresh_approval(): void
+    {
+        Queue::fake();
+        [$admin, $article] = $this->qualityArticle();
+        $task = $article->task()->firstOrFail();
+        $task->forceFill(['publish_scope' => 'distribution_only'])->save();
+        $check = app(ArticleAiQualityInspectionService::class)->createOrReuse($article, dispatch: false);
+        $check->forceFill([
+            'status' => 'completed',
+            'decision' => 'passed',
+            'score' => 96,
+            'active_dedupe_key' => null,
+            'finished_at' => now(),
+        ])->save();
+        $article->forceFill([
+            'task_id' => null,
+            'status' => 'published',
+            'review_status' => 'approved',
+            'published_at' => now(),
+            'ai_quality_required_at_creation' => false,
+            'ai_quality_policy_snapshot' => null,
+        ])->save();
+
+        app(ArticleGeoFlowService::class)->updateArticle($article->id, [
+            'task_id' => $task->id,
+            'content' => '服务客户为 800 家，正文已经更新。',
+        ], $admin->id);
+
+        $article->refresh();
+        $this->assertSame($task->id, $article->task_id);
+        $this->assertSame('draft', $article->status);
+        $this->assertSame('pending', $article->review_status);
+        $this->assertNull($article->published_at);
+        $this->assertSame('stale', $check->fresh()->status);
     }
 
     public function test_api_task_rebinding_migrates_knowledge_sources_between_independent_and_task_policies(): void

--- a/tests/Feature/AdminArticleRiskWorkflowTest.php
+++ b/tests/Feature/AdminArticleRiskWorkflowTest.php
@@ -8,8 +8,10 @@ use App\Models\Article;
 use App\Models\Author;
 use App\Models\Category;
 use App\Models\SensitiveWord;
+use App\Models\Task;
 use App\Services\GeoFlow\ArticleRiskGate;
 use App\Services\GeoFlow\ArticleRiskScanner;
+use App\Services\GeoFlow\DistributionOrchestrator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
@@ -277,6 +279,188 @@ class AdminArticleRiskWorkflowTest extends TestCase
         $this->assertSame($this->admin->id, $latestScan->admin_id);
         $this->assertFalse($latestScan->is($previousScan));
         $this->assertSame(2, $article->riskScans()->count());
+    }
+
+    public function test_distribution_only_article_update_stays_private_and_enters_distribution(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Admin distribution only task',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'review_status' => 'approved',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')->once()->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.articles.update', ['articleId' => $article->id]), $this->articlePayload([
+                'status' => 'published',
+                'review_status' => 'approved',
+            ]))
+            ->assertRedirect(route('admin.articles.edit', ['articleId' => $article->id]))
+            ->assertSessionDoesntHaveErrors();
+
+        $article->refresh();
+        $this->assertSame('private', $article->status);
+        $this->assertSame('approved', $article->review_status);
+        $this->assertNull($article->published_at);
+    }
+
+    public function test_distribution_only_explicit_private_update_does_not_enter_distribution(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Admin explicit private task',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'status' => 'private',
+            'review_status' => 'approved',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.articles.update', ['articleId' => $article->id]), $this->articlePayload([
+                'status' => 'private',
+                'review_status' => 'approved',
+            ]))
+            ->assertRedirect(route('admin.articles.edit', ['articleId' => $article->id]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertNull($article->fresh()->published_at);
+    }
+
+    public function test_distribution_only_batch_publish_stays_private_and_enters_distribution(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Admin batch distribution only task',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'review_status' => 'approved',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')->once()->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.articles.batch.update-status'), [
+                'article_ids' => [$article->id],
+                'new_status' => 'published',
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $article->refresh();
+        $this->assertSame('private', $article->status);
+        $this->assertSame('approved', $article->review_status);
+        $this->assertNull($article->published_at);
+    }
+
+    public function test_distribution_only_batch_private_status_does_not_enter_distribution(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Admin batch private task',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'status' => 'private',
+            'review_status' => 'approved',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.articles.batch.update-status'), [
+                'article_ids' => [$article->id],
+                'new_status' => 'private',
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertNull($article->fresh()->published_at);
+    }
+
+    public function test_distribution_only_batch_review_stays_private_and_enters_distribution(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Admin batch review distribution only task',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'need_review' => 0,
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle(['task_id' => $task->id]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')->once()->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.articles.batch.update-review'), [
+                'article_ids' => [$article->id],
+                'review_status' => 'approved',
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $article->refresh();
+        $this->assertSame('private', $article->status);
+        $this->assertSame('approved', $article->review_status);
+        $this->assertNull($article->published_at);
+    }
+
+    public function test_distribution_only_batch_review_of_private_article_does_not_enter_distribution(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Admin batch private review task',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'need_review' => 1,
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'status' => 'private',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.articles.batch.update-review'), [
+                'article_ids' => [$article->id],
+                'review_status' => 'approved',
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertSame('approved', $article->fresh()->review_status);
+        $this->assertNull($article->fresh()->published_at);
     }
 
     public function test_non_risk_admin_update_preserves_a_fresh_warning_override(): void

--- a/tests/Feature/AdminTasksPageTest.php
+++ b/tests/Feature/AdminTasksPageTest.php
@@ -18,6 +18,7 @@ use App\Models\TitleLibrary;
 use App\Models\WorkerHeartbeat;
 use App\Services\GeoFlow\DistributionOrchestrator;
 use App\Services\GeoFlow\JobQueueService;
+use App\Services\GeoFlow\TaskLifecycleService;
 use App\Support\AdminWeb;
 use App\Support\GeoFlow\ApiKeyCrypto;
 use Illuminate\Database\Eloquent\Collection;
@@ -25,6 +26,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -856,6 +858,36 @@ class AdminTasksPageTest extends TestCase
         $task->refresh();
         $this->assertNull($task->knowledge_base_id);
         $this->assertSame(0, $task->knowledgeBases()->count());
+    }
+
+    public function test_changing_task_to_distribution_only_makes_published_articles_private(): void
+    {
+        Queue::fake();
+        [$task, $article] = $this->createPublishedTaskArticle('scope-narrowing');
+
+        app(TaskLifecycleService::class)->updateTask((int) $task->id, [
+            'publish_scope' => 'distribution_only',
+        ]);
+
+        $this->assertSame('distribution_only', $task->fresh()->publish_scope);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertNull($article->fresh()->published_at);
+    }
+
+    public function test_changing_distribution_only_task_to_local_scope_does_not_publish_private_articles(): void
+    {
+        Queue::fake();
+        [$task, $article] = $this->createPublishedTaskArticle('scope-widening');
+        $task->update(['publish_scope' => 'distribution_only']);
+        $article->update(['status' => 'private', 'published_at' => null]);
+
+        app(TaskLifecycleService::class)->updateTask((int) $task->id, [
+            'publish_scope' => 'local_and_distribution',
+        ]);
+
+        $this->assertSame('local_and_distribution', $task->fresh()->publish_scope);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertNull($article->fresh()->published_at);
     }
 
     public function test_stale_task_edit_cannot_restore_distribution_state_after_channel_deletion(): void
@@ -1857,6 +1889,39 @@ class AdminTasksPageTest extends TestCase
         }
 
         return $knowledgeBases;
+    }
+
+    /** @return array{Task, Article} */
+    private function createPublishedTaskArticle(string $suffix): array
+    {
+        $task = Task::query()->create([
+            'name' => 'Publish scope task '.$suffix,
+            'status' => 'paused',
+            'schedule_enabled' => 0,
+            'publish_scope' => 'local_and_distribution',
+            'ai_quality_enabled' => false,
+        ]);
+        $category = Category::query()->create([
+            'name' => 'Publish scope category '.$suffix,
+            'slug' => 'publish-scope-'.$suffix,
+        ]);
+        $author = Author::query()->create([
+            'name' => 'Publish scope author '.$suffix,
+            'email' => $suffix.'@example.test',
+        ]);
+        $article = Article::query()->create([
+            'title' => 'Publish scope article '.$suffix,
+            'slug' => 'publish-scope-article-'.$suffix,
+            'content' => 'Publish scope article content.',
+            'category_id' => $category->id,
+            'author_id' => $author->id,
+            'task_id' => $task->id,
+            'status' => 'published',
+            'review_status' => 'approved',
+            'published_at' => now(),
+        ]);
+
+        return [$task, $article];
     }
 
     /**

--- a/tests/Feature/ApiArticleRiskWorkflowTest.php
+++ b/tests/Feature/ApiArticleRiskWorkflowTest.php
@@ -17,6 +17,7 @@ use App\Models\Task;
 use App\Services\GeoFlow\ArticleRiskGate;
 use App\Services\GeoFlow\ArticleRiskScanner;
 use App\Services\GeoFlow\ArticleWorkflowTransitionService;
+use App\Services\GeoFlow\DistributionOrchestrator;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -212,6 +213,47 @@ class ApiArticleRiskWorkflowTest extends TestCase
         $this->assertTrue($scan->is_overridden);
         $this->assertSame('Reviewed by the API editor.', $scan->override_reason);
         $this->assertSame($this->admin->id, $scan->overridden_by_admin_id);
+    }
+
+    public function test_distribution_only_create_stays_private_and_enters_distribution(): void
+    {
+        $task = $this->createDistributionOnlyTask();
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')
+            ->once()
+            ->with(\Mockery::on(fn (mixed $candidate): bool => $candidate instanceof Article
+                && (int) $candidate->task_id === (int) $task->id))
+            ->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $response = $this->postArticle($this->articlePayload([
+            'task_id' => $task->id,
+            'status' => 'published',
+            'review_status' => 'approved',
+        ]));
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'private')
+            ->assertJsonPath('data.review_status', 'approved')
+            ->assertJsonPath('data.published_at', null);
+    }
+
+    public function test_distribution_only_explicit_private_create_does_not_enter_distribution(): void
+    {
+        $task = $this->createDistributionOnlyTask();
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->postArticle($this->articlePayload([
+            'task_id' => $task->id,
+            'status' => 'private',
+            'review_status' => 'approved',
+        ]))
+            ->assertCreated()
+            ->assertJsonPath('data.status', 'private')
+            ->assertJsonPath('data.review_status', 'approved')
+            ->assertJsonPath('data.published_at', null);
     }
 
     public function test_warning_auto_approved_create_returns_409_as_an_unoverridden_draft(): void
@@ -517,6 +559,74 @@ class ApiArticleRiskWorkflowTest extends TestCase
         $this->assertSame($this->admin->id, $scan->admin_id);
     }
 
+    public function test_distribution_only_publish_stays_private_and_enters_distribution(): void
+    {
+        $task = $this->createDistributionOnlyTask();
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'review_status' => 'approved',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')
+            ->once()
+            ->with(\Mockery::on(fn (mixed $candidate): bool => $candidate instanceof Article
+                && (int) $candidate->task_id === (int) $task->id))
+            ->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->withHeader('Authorization', 'Bearer '.$this->token)
+            ->postJson("/api/v1/articles/{$article->id}/publish")
+            ->assertOk()
+            ->assertJsonPath('data.status', 'private')
+            ->assertJsonPath('data.review_status', 'approved')
+            ->assertJsonPath('data.published_at', null);
+    }
+
+    public function test_distribution_only_approved_review_stays_private_and_enters_distribution(): void
+    {
+        $task = $this->createDistributionOnlyTask(['need_review' => 0]);
+        $article = $this->createArticle(['task_id' => $task->id]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')
+            ->once()
+            ->with(\Mockery::on(fn (mixed $candidate): bool => $candidate instanceof Article
+                && (int) $candidate->task_id === (int) $task->id))
+            ->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->withHeader('Authorization', 'Bearer '.$this->token)
+            ->postJson("/api/v1/articles/{$article->id}/review", [
+                'review_status' => 'approved',
+                'review_note' => 'Ready for channel publication.',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'private')
+            ->assertJsonPath('data.review_status', 'approved')
+            ->assertJsonPath('data.published_at', null);
+    }
+
+    public function test_distribution_only_approved_review_keeps_explicit_private_article_out_of_distribution(): void
+    {
+        $task = $this->createDistributionOnlyTask(['need_review' => 1]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'status' => 'private',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $this->withHeader('Authorization', 'Bearer '.$this->token)
+            ->postJson("/api/v1/articles/{$article->id}/review", [
+                'review_status' => 'approved',
+                'review_note' => 'Approved for storage only.',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'private')
+            ->assertJsonPath('data.review_status', 'approved')
+            ->assertJsonPath('data.published_at', null);
+    }
+
     public function test_pending_article_cannot_be_published(): void
     {
         $article = $this->createArticle(['review_status' => 'pending']);
@@ -704,6 +814,18 @@ class ApiArticleRiskWorkflowTest extends TestCase
             'author_id' => $this->author->id,
             'status' => 'draft',
             'review_status' => 'pending',
+        ], $overrides));
+    }
+
+    /** @param array<string, mixed> $overrides */
+    private function createDistributionOnlyTask(array $overrides = []): Task
+    {
+        return Task::query()->create(array_merge([
+            'name' => 'API distribution only task '.uniqid(),
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
         ], $overrides));
     }
 }

--- a/tests/Feature/ArticleAiQualityInspectionServiceTest.php
+++ b/tests/Feature/ArticleAiQualityInspectionServiceTest.php
@@ -33,6 +33,7 @@ use App\Services\GeoFlow\ArticleAiQualityRetrievalCoordinator;
 use App\Services\GeoFlow\ArticleAiQualityRolloutPolicy;
 use App\Services\GeoFlow\ArticleFactCandidateExtractor;
 use App\Services\GeoFlow\ArticleWorkflowTransitionService;
+use App\Services\GeoFlow\DistributionOrchestrator;
 use App\Services\GeoFlow\KnowledgeFacts\ArticleAtomicFactInspector;
 use App\Services\GeoFlow\KnowledgeRetrievalService;
 use App\Support\GeoFlow\ApiKeyCrypto;
@@ -42,6 +43,7 @@ use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use InvalidArgumentException;
 use Mockery;
@@ -2219,6 +2221,9 @@ class ArticleAiQualityInspectionServiceTest extends TestCase
     {
         $this->bindPassingReviewer();
         $article = $this->createQualityFixture('restore-private-target', needReview: false);
+        $orchestrator = Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
         $service = app(ArticleAiQualityInspectionService::class);
         $check = $service->requestManualInspection(
             $article,
@@ -2235,6 +2240,103 @@ class ArticleAiQualityInspectionServiceTest extends TestCase
         $this->assertSame('passed', $completed->decision);
         $this->assertSame('private', $article->fresh()->status);
         $this->assertSame('approved', $article->fresh()->review_status);
+    }
+
+    public function test_passing_inspection_enqueues_a_publish_target_already_normalized_to_private(): void
+    {
+        $this->bindPassingReviewer();
+        $article = $this->createQualityFixture('distribution-only-pre-normalized', needReview: false);
+        $article->task()->update(['publish_scope' => 'distribution_only']);
+        $article->forceFill([
+            'status' => 'private',
+            'review_status' => 'approved',
+            'published_at' => null,
+        ])->save();
+        $orchestrator = Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')->once()->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+        $service = app(ArticleAiQualityInspectionService::class);
+        $check = $service->requestManualInspection(
+            $article,
+            dispatch: false,
+            requestedWorkflowState: [
+                'status' => 'published',
+                'review_status' => 'approved',
+                'published_at' => now(),
+            ],
+        );
+
+        $completed = $service->process($check);
+
+        $this->assertSame('passed', $completed->decision);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertSame('approved', $article->fresh()->review_status);
+        $this->assertNull($article->fresh()->published_at);
+    }
+
+    public function test_newer_private_intent_cancels_a_pending_distribution_only_publish_request(): void
+    {
+        $this->bindPassingReviewer();
+        $article = $this->createQualityFixture('distribution-only-cancelled-target', needReview: false);
+        $article->task()->update(['publish_scope' => 'distribution_only']);
+        $article->forceFill([
+            'status' => 'private',
+            'review_status' => 'approved',
+            'published_at' => null,
+        ])->save();
+        $orchestrator = Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldNotReceive('enqueueForArticle');
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+        $service = app(ArticleAiQualityInspectionService::class);
+        $check = $service->requestManualInspection(
+            $article,
+            dispatch: false,
+            requestedWorkflowState: [
+                'status' => 'published',
+                'review_status' => 'approved',
+                'published_at' => now(),
+            ],
+        );
+
+        DB::transaction(function () use ($article): void {
+            $lockedArticle = Article::query()->whereKey((int) $article->id)->lockForUpdate()->firstOrFail();
+            app(ArticleWorkflowTransitionService::class)->cancelPendingDistributionIntent($lockedArticle);
+        });
+
+        $completed = $service->process($check);
+        $check->refresh();
+
+        $this->assertSame('passed', $completed->decision);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertSame('private', data_get($check->execution_meta, 'requested_workflow_state.status'));
+        $this->assertNotNull(data_get($check->execution_meta, 'distribution_intent_cancelled_at'));
+    }
+
+    public function test_passing_inspection_keeps_distribution_only_publish_target_private_and_enqueues_it(): void
+    {
+        $this->bindPassingReviewer();
+        $article = $this->createQualityFixture('distribution-only-target', needReview: false);
+        $article->task()->update(['publish_scope' => 'distribution_only']);
+        $orchestrator = Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')->once()->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+        $service = app(ArticleAiQualityInspectionService::class);
+        $check = $service->requestManualInspection(
+            $article,
+            dispatch: false,
+            requestedWorkflowState: [
+                'status' => 'published',
+                'review_status' => 'approved',
+                'published_at' => now(),
+            ],
+        );
+
+        $completed = $service->process($check);
+
+        $this->assertSame('passed', $completed->decision);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertSame('approved', $article->fresh()->review_status);
+        $this->assertNull($article->fresh()->published_at);
     }
 
     public function test_failed_post_quality_workflow_is_persisted_and_reconciled(): void

--- a/tests/Feature/ArticleWorkflowTransitionServiceTest.php
+++ b/tests/Feature/ArticleWorkflowTransitionServiceTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature;
 
+use App\Exceptions\ArticleAiQualityGateException;
 use App\Exceptions\ArticleRiskGateException;
 use App\Models\Article;
 use App\Models\Author;
 use App\Models\Category;
 use App\Models\SensitiveWord;
 use App\Models\Task;
+use App\Services\GeoFlow\ArticlePublicationQualityGate;
 use App\Services\GeoFlow\ArticleWorkflowTransitionService;
 use App\Support\GeoFlow\ArticleWorkflow;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -105,6 +107,68 @@ class ArticleWorkflowTransitionServiceTest extends TestCase
         $this->assertTrue($guardObservedTask);
         $this->assertSame('published', $transitioned->status);
         $this->assertSame((int) $task->id, (int) $transitioned->task_id);
+    }
+
+    public function test_distribution_only_task_forces_a_publish_transition_to_private(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Distribution only workflow transition',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'review_status' => 'approved',
+        ]);
+        $this->assertSame('distribution_only', $task->fresh()->publish_scope);
+
+        $transitioned = app(ArticleWorkflowTransitionService::class)->transition(
+            $article,
+            ArticleWorkflow::normalizeState('published', 'approved'),
+            'service_task_publish',
+        );
+
+        $this->assertSame('private', $transitioned->status);
+        $this->assertSame('approved', $transitioned->review_status);
+        $this->assertNull($transitioned->published_at);
+    }
+
+    public function test_ai_quality_rejection_does_not_preserve_invalid_distribution_only_publication(): void
+    {
+        $task = Task::query()->create([
+            'name' => 'Distribution only quality rejection',
+            'status' => 'active',
+            'schedule_enabled' => 1,
+            'publish_scope' => 'distribution_only',
+            'ai_quality_enabled' => false,
+        ]);
+        $article = $this->createArticle([
+            'task_id' => $task->id,
+            'status' => 'published',
+            'review_status' => 'approved',
+            'published_at' => now(),
+        ]);
+        $qualityGate = \Mockery::mock(ArticlePublicationQualityGate::class);
+        $qualityGate->shouldReceive('check')
+            ->once()
+            ->andThrow(new ArticleAiQualityGateException('article_ai_quality_pending', 'Quality pending.'));
+        $service = new ArticleWorkflowTransitionService($qualityGate);
+
+        try {
+            $service->transition(
+                $article,
+                ArticleWorkflow::normalizeState('published', 'approved'),
+                'service_task_publish',
+            );
+            $this->fail('Expected the AI quality gate to reject the transition.');
+        } catch (ArticleAiQualityGateException) {
+            $article->refresh();
+            $this->assertSame('private', $article->status);
+            $this->assertSame('approved', $article->review_status);
+            $this->assertNull($article->published_at);
+        }
     }
 
     /** @param array<string, mixed> $attributes */

--- a/tests/Feature/HostedSites/HostedSitePublicRenderingTest.php
+++ b/tests/Feature/HostedSites/HostedSitePublicRenderingTest.php
@@ -70,6 +70,46 @@ class HostedSitePublicRenderingTest extends TestCase
         $this->assertNotNull($betaArticle->id);
     }
 
+    public function test_primary_site_excludes_distribution_only_articles_from_every_public_entry(): void
+    {
+        $distributionOnlyArticle = $this->articleFixture(
+            'Channel only article',
+            'channel-only-article',
+            'published',
+        );
+        $localArticle = $this->articleFixture(
+            'Primary local article',
+            'primary-local-article',
+            'published',
+            'local_and_distribution',
+        );
+        $archiveYear = $localArticle->published_at->format('Y');
+        $archiveMonth = $localArticle->published_at->format('m');
+
+        $this->get('http://primary.test/')
+            ->assertOk()
+            ->assertSee($localArticle->title)
+            ->assertDontSee($distributionOnlyArticle->title);
+        $this->get('http://primary.test/category/'.$localArticle->category->slug)
+            ->assertOk()
+            ->assertSee($localArticle->title)
+            ->assertDontSee($distributionOnlyArticle->title);
+        $this->get('http://primary.test/article/'.$localArticle->slug)->assertOk();
+        $this->get('http://primary.test/article/'.$distributionOnlyArticle->slug)->assertNotFound();
+        $this->get("http://primary.test/archive/{$archiveYear}/{$archiveMonth}")
+            ->assertOk()
+            ->assertSee($localArticle->title)
+            ->assertDontSee($distributionOnlyArticle->title);
+        $this->get('http://primary.test/archive')
+            ->assertOk()
+            ->assertViewHas('archives', fn (array $archives): bool => count($archives) === 1
+                && $archives[0]['count'] === 1);
+        $this->get('http://primary.test/sitemap.xml')
+            ->assertOk()
+            ->assertSee($localArticle->slug)
+            ->assertDontSee($distributionOnlyArticle->slug);
+    }
+
     public function test_hosted_about_forms_and_submission_ownership_use_the_site_allowlist(): void
     {
         [$profile] = $this->siteFixture('alpha', 'Alpha Site', 'Alpha article', [
@@ -252,12 +292,16 @@ class HostedSitePublicRenderingTest extends TestCase
         return [$profile, $article];
     }
 
-    private function articleFixture(string $title, string $slug, string $status): Article
-    {
+    private function articleFixture(
+        string $title,
+        string $slug,
+        string $status,
+        string $publishScope = 'distribution_only',
+    ): Article {
         $task = Task::query()->create([
             'name' => $title.' task',
             'status' => 'active',
-            'publish_scope' => 'distribution_only',
+            'publish_scope' => $publishScope,
         ]);
         $category = Category::query()->firstOrCreate(
             ['slug' => 'ai'],

--- a/tests/Feature/ReconcileDistributionOnlyArticlesCommandTest.php
+++ b/tests/Feature/ReconcileDistributionOnlyArticlesCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Article;
+use App\Models\Author;
+use App\Models\Category;
+use App\Models\Task;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReconcileDistributionOnlyArticlesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_dry_by_default_and_apply_repairs_only_invalid_articles(): void
+    {
+        $distributionTask = $this->createTask('distribution_only');
+        $localTask = $this->createTask('local_and_distribution');
+        $invalidArticle = $this->createArticle('invalid', $distributionTask, 'published');
+        $validPrivateArticle = $this->createArticle('valid-private', $distributionTask, 'private');
+        $localArticle = $this->createArticle('local', $localTask, 'published');
+        $tasklessArticle = $this->createArticle('taskless', null, 'published');
+
+        $this->artisan('geoflow:reconcile-distribution-only-articles')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Matched distribution-only published articles: 1 (dry run)');
+
+        $this->assertSame('published', $invalidArticle->fresh()->status);
+        $this->assertNotNull($invalidArticle->fresh()->published_at);
+
+        $this->artisan('geoflow:reconcile-distribution-only-articles', ['--apply' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Reconciled distribution-only published articles: 1');
+
+        $this->assertSame('private', $invalidArticle->fresh()->status);
+        $this->assertNull($invalidArticle->fresh()->published_at);
+        $this->assertSame('private', $validPrivateArticle->fresh()->status);
+        $this->assertSame('published', $localArticle->fresh()->status);
+        $this->assertSame('published', $tasklessArticle->fresh()->status);
+
+        $this->artisan('geoflow:reconcile-distribution-only-articles', ['--apply' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Reconciled distribution-only published articles: 0');
+    }
+
+    private function createTask(string $publishScope): Task
+    {
+        return Task::query()->create([
+            'name' => 'Reconcile task '.uniqid(),
+            'status' => 'paused',
+            'schedule_enabled' => 0,
+            'publish_scope' => $publishScope,
+        ]);
+    }
+
+    private function createArticle(string $suffix, ?Task $task, string $status): Article
+    {
+        $category = Category::query()->create([
+            'name' => 'Reconcile category '.$suffix,
+            'slug' => 'reconcile-category-'.$suffix,
+        ]);
+        $author = Author::query()->create([
+            'name' => 'Reconcile author '.$suffix,
+            'email' => 'reconcile-'.$suffix.'@example.test',
+        ]);
+
+        return Article::query()->create([
+            'title' => 'Reconcile article '.$suffix,
+            'slug' => 'reconcile-article-'.$suffix,
+            'content' => 'Reconcile article content.',
+            'category_id' => $category->id,
+            'author_id' => $author->id,
+            'task_id' => $task?->id,
+            'status' => $status,
+            'review_status' => 'approved',
+            'published_at' => $status === 'published' ? now() : null,
+        ]);
+    }
+}

--- a/tests/Feature/WorkerArticleRiskWorkflowTest.php
+++ b/tests/Feature/WorkerArticleRiskWorkflowTest.php
@@ -9,6 +9,7 @@ use App\Models\Category;
 use App\Models\SensitiveWord;
 use App\Models\Task;
 use App\Services\GeoFlow\ArticleRiskGate;
+use App\Services\GeoFlow\DistributionOrchestrator;
 use App\Services\GeoFlow\WorkerExecutionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -129,20 +130,63 @@ class WorkerArticleRiskWorkflowTest extends TestCase
         $this->assertSame(0, (int) $task->fresh()->published_count);
     }
 
+    public function test_worker_keeps_approved_distribution_only_article_private_and_enqueues_it(): void
+    {
+        [$task, $article] = $this->createTaskArticle([], [
+            'publish_scope' => 'distribution_only',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')
+            ->once()
+            ->with((int) $article->id)
+            ->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $result = app(WorkerExecutionService::class)->executeTask((int) $task->id);
+
+        $this->assertSame((int) $article->id, $result['article_id']);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertSame('approved', $article->fresh()->review_status);
+        $this->assertNull($article->fresh()->published_at);
+    }
+
+    public function test_worker_keeps_auto_approved_distribution_only_article_private_and_enqueues_it(): void
+    {
+        [$task, $article] = $this->createTaskArticle([
+            'review_status' => 'auto_approved',
+        ], [
+            'publish_scope' => 'distribution_only',
+        ]);
+        $orchestrator = \Mockery::mock(DistributionOrchestrator::class);
+        $orchestrator->shouldReceive('enqueueForArticle')
+            ->once()
+            ->with((int) $article->id)
+            ->andReturn([]);
+        $this->app->instance(DistributionOrchestrator::class, $orchestrator);
+
+        $result = app(WorkerExecutionService::class)->executeTask((int) $task->id);
+
+        $this->assertSame((int) $article->id, $result['article_id']);
+        $this->assertSame('private', $article->fresh()->status);
+        $this->assertSame('auto_approved', $article->fresh()->review_status);
+        $this->assertNull($article->fresh()->published_at);
+    }
+
     /**
      * @param  array<string, mixed>  $articleOverrides
+     * @param  array<string, mixed>  $taskOverrides
      * @return array{Task, Article}
      */
-    private function createTaskArticle(array $articleOverrides = []): array
+    private function createTaskArticle(array $articleOverrides = [], array $taskOverrides = []): array
     {
-        $task = Task::query()->create([
+        $task = Task::query()->create(array_merge([
             'name' => 'Risk worker task',
             'status' => 'active',
             'schedule_enabled' => 1,
             'publish_interval' => 3600,
             'publish_scope' => 'local_and_distribution',
             'next_publish_at' => now()->subMinute(),
-        ]);
+        ], $taskOverrides));
         $category = Category::query()->create([
             'name' => 'Worker risk',
             'slug' => 'worker-risk-'.uniqid(),


### PR DESCRIPTION
## 变更说明 / Summary

- 将 `distribution_only` 的发布结果统一归一化为主站私有状态，同时保留渠道分发意图
- 覆盖后台、批量、API、Worker、AI 质检通过、任务范围切换和 API 任务重绑入口
- 主站首页、分类、详情、归档和 sitemap 统一排除仅分发文章
- 增加默认 dry-run、支持 `--apply`、可重复执行的历史数据修复命令
- 修复复核发现的任务改绑分发竞态、异步质检旧意图竞态和大任务参数上限风险

Fixes #106

## 验证 / Verification

- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer test` — 3528 passed, 14 skipped, 35230 assertions
- `npm run build`
- `npm run test:analytics` — 191 passed
- `composer audit --locked --no-interaction`
- `npm audit --audit-level=high --registry=https://registry.npmjs.org`
- 聚焦回归 — 242 passed, 2005 assertions

## CLA 声明 / CLA declaration

可构成版权作品的贡献必须接受 [GEOFlow Contributor License Agreement v1.0](https://github.com/yaojingang/GEOFlow/blob/main/CLA.md)。
Copyrightable contributions require acceptance of the [GEOFlow Contributor License Agreement v1.0](https://github.com/yaojingang/GEOFlow/blob/main/CLA.md).

- 贡献者类型 / Contributor type:
- 法定姓名或企业法定名称 / Legal name or entity name:
- 企业授权代表姓名及职务（如适用）/ Authorized representative and title (if applicable):
- GitHub 用户名:
- 接受日期 / Date accepted:
- [ ] 我已阅读并接受 GEOFlow CLA v1.0，并确认有权授予其中约定的权利。

## 检查清单 / Checklist

- [x] 本次提交不包含第三方材料。
- [x] 本次提交不包含凭据、客户数据或其他敏感信息。
- [x] 已为行为变化补充测试。